### PR TITLE
Wizard: Add progress bar when cloning

### DIFF
--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/i18n/Messages.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/i18n/Messages.java
@@ -21,6 +21,7 @@ public class Messages extends NLS {
 	public static String AbapGitView_repos_not_loaded;
 	public static String AbapGitView_task_fetch_repos;
 	public static String AbapGitView_task_fetch_repos_error;
+	public static String AbapGitWizard_task_cloning_repository;
 	public static String AbapGitWizard_title;
 	public static String AbapGitWizardPageBranchAndPackage_btn_browse;
 	public static String AbapGitWizardPageBranchAndPackage_combobox_branch_message;

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/i18n/messages.properties
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/i18n/messages.properties
@@ -15,6 +15,7 @@ AbapGitView_repos_in_project=abapGit repositories in project {0}\:
 AbapGitView_repos_not_loaded=abapGit repositories in project {0} are not loaded, yet. Press 'Refresh' to load the repository list.
 AbapGitView_task_fetch_repos=Fetching abapGit Repositories
 AbapGitView_task_fetch_repos_error=Error fetching abapGit Repositories
+AbapGitWizard_task_cloning_repository=Cloning repository...
 AbapGitWizard_title=Clone abapGit Repository
 AbapGitWizardPageBranchAndPackage_btn_browse=Browse...
 AbapGitWizardPageBranchAndPackage_combobox_branch_message=Specify a branch

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/wizards/AbapGitWizard.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/wizards/AbapGitWizard.java
@@ -74,6 +74,7 @@ public class AbapGitWizard extends Wizard {
 
 				@Override
 				public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
+					monitor.beginTask(Messages.AbapGitWizard_task_cloning_repository, IProgressMonitor.UNKNOWN);
 					IRepositoryService repoService = RepositoryServiceFactory.createRepositoryService(AbapGitWizard.this.destination,
 							monitor);
 					repoService.cloneRepository(AbapGitWizard.this.cloneData.url, AbapGitWizard.this.cloneData.branch, AbapGitWizard.this.cloneData.packageRef.getName(),


### PR DESCRIPTION
Call monitor.beginTask() so that a moving progress bar with a cancel
button is shown.