### PR TITLE
https://github.com/abapGit/ADT_Frontend/issues/92

### DIFF
--- a/org.abapgit.adt.ui/plugin.properties
+++ b/org.abapgit.adt.ui/plugin.properties
@@ -2,3 +2,10 @@
 category.name = abapGit
 view.name = abapGit Repositories
 Bundle-Name = abapGit ADT UI Plug-in
+
+abapGit.command.openView.name = Open abapGit repositories command
+abapGit.command.openView.label = AbapGit repositories 
+abapGit.command.openView.tooltip = Open abapGit repositories view
+
+abapGit.command.pull.label = AbapGit pull
+abapGit.command.pull.tooltip = AbapGit pull not yet implemented

--- a/org.abapgit.adt.ui/plugin.xml
+++ b/org.abapgit.adt.ui/plugin.xml
@@ -80,7 +80,14 @@
                       <adapt
                             type="com.sap.adt.tools.core.project.IAbapProject">
                       </adapt>
-                                           
+                     
+                    <instanceof
+                         value="org.eclipse.core.resources.IProject">
+                      </instanceof>
+                      <adapt
+                            type="org.eclipse.core.resources.IProject">
+                      </adapt>
+                      
                    </or>
                 </and>
              </iterate>

--- a/org.abapgit.adt.ui/plugin.xml
+++ b/org.abapgit.adt.ui/plugin.xml
@@ -13,5 +13,173 @@
             name="%view.name">
       </view>
    </extension>
+   
+   <extension
+         point="org.eclipse.ui.commands">
+      <category
+            name="ABAP CI Category"
+            id="abapci.commands.category"
+            categoryId="abapci.commands.category">
+      </category>
+      <command
+            name="abapGit.command.openView"
+            categoryId="org.abapgit.adt.ui.category"
+            id="org.abapgit.adt.ui.command.abapgit.openView">
+      </command>
+      <command
+            name="abapGit.command.pull"
+            categoryId="org.abapgit.adt.ui.category"
+            id="org.abapgit.adt.ui.command.abapgit.pull">
+      </command>
+   </extension>
+ 
+   <extension
+         point="org.eclipse.ui.handlers">
+      <handler
+		class="org.abapgit.adt.ui.internal.handlers.AbapGitOpenViewHandler"            
+		commandId="org.abapgit.adt.ui.command.abapgit.openView">
+      </handler>
+      <handler
+		class="org.abapgit.adt.ui.internal.handlers.AbapGitPullHandler"            
+		commandId="org.abapgit.adt.ui.command.abapgit.pull">
+      </handler>
+   </extension> 
 
+
+   <extension
+         point="org.eclipse.ui.menus">
+
+      <menuContribution  
+          allPopups="false"        
+          locationURI="popup:org.eclipse.ui.navigator.ProjectExplorer#PopupMenu?before=additions">
+       <command
+             commandId="org.abapgit.adt.ui.command.abapgit.openView"
+             id="gitMenu"
+             label="%abapGit.command.openView.label"
+             icon="icons/view/abapgit.png"
+             tooltip="%abapGit.command.openView.tooltip">
+          <visibleWhen
+                checkEnabled="false">
+             <iterate
+                   ifEmpty="false"
+                   operator="or">
+                <and>
+                <or>
+                      property="com.sap.adt.project.hasNature"
+                         value="com.sap.adt.abapnature">
+  
+                      <instanceof
+                            value="com.sap.adt.tools.core.IAdtObjectReference">
+                      </instanceof>
+                      <adapt
+                            type="com.sap.adt.tools.core.IAdtObjectReference">
+                      </adapt>
+                      <instanceof
+                         value="com.sap.adt.tools.core.project.IAbapProject">
+                      </instanceof>
+                      <adapt
+                            type="com.sap.adt.tools.core.project.IAbapProject">
+                      </adapt>
+                                           
+                   </or>
+                </and>
+             </iterate>
+          </visibleWhen>
+       </command>
+    </menuContribution>    
+   
+   
+    <menuContribution
+            allPopups="false"
+            locationURI="popup:org.eclipse.ui.navigator.ProjectExplorer#PopupMenu?before=additions">
+         <menu
+               id="gitMenu"
+               label="Git actions">
+            <separator>
+            </separator>
+           <visibleWhen
+                checkEnabled="false">
+             <iterate
+                   ifEmpty="false"
+                   operator="or">
+                <and>
+                <or>
+                      property="com.sap.adt.project.hasNature"
+                         value="com.sap.adt.abapnature">
+  
+                      <instanceof
+                            value="com.sap.adt.tools.core.IAdtObjectReference">
+                      </instanceof>
+                      <adapt
+                            type="com.sap.adt.tools.core.IAdtObjectReference">
+                      </adapt>
+                      <instanceof
+                         value="com.sap.adt.tools.core.project.IAbapProject">
+                      </instanceof>
+                      <adapt
+                            type="com.sap.adt.tools.core.project.IAbapProject">
+                      </adapt>
+                     
+                    <instanceof
+                         value="org.eclipse.core.resources.IProject">
+                      </instanceof>
+                      <adapt
+                            type="org.eclipse.core.resources.IProject">
+                      </adapt>
+                      
+                   </or>
+                </and>
+             </iterate>
+          </visibleWhen>
+       </menu>
+ </menuContribution>
+
+          <menuContribution
+                allPopups="false"
+                locationURI="popup:gitMenu?after=additions">
+             <command
+                   commandId="org.abapgit.adt.ui.command.abapgit.pull"
+                   label="%abapGit.command.pull.label"
+                   tooltip="%abapGit.command.pull.tooltip"
+                style="push">
+          <visibleWhen
+                checkEnabled="false">
+             <iterate
+                   ifEmpty="false"
+                   operator="or">
+                <and>
+                <or>
+                      property="com.sap.adt.project.hasNature"
+                         value="com.sap.adt.abapnature">
+  
+                      <instanceof
+                            value="com.sap.adt.tools.core.IAdtObjectReference">
+                      </instanceof>
+                      <adapt
+                            type="com.sap.adt.tools.core.IAdtObjectReference">
+                      </adapt>
+                      <instanceof
+                         value="com.sap.adt.tools.core.project.IAbapProject">
+                      </instanceof>
+                      <adapt
+                            type="com.sap.adt.tools.core.project.IAbapProject">
+                      </adapt>
+                     
+                    <instanceof
+                         value="org.eclipse.core.resources.IProject">
+                      </instanceof>
+                      <adapt
+                            type="org.eclipse.core.resources.IProject">
+                      </adapt>
+                      
+                   </or>
+                </and>
+             </iterate>
+          </visibleWhen>
+             </command>
+          </menuContribution>
+    
+    
+
+</extension> 
 </plugin>

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/handlers/AbapGitOpenViewHandler.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/handlers/AbapGitOpenViewHandler.java
@@ -1,0 +1,36 @@
+package org.abapgit.adt.ui.internal.handlers;
+
+import org.abapgit.adt.ui.internal.views.AbapGitView;
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+
+public class AbapGitOpenViewHandler extends AbstractHandler {
+
+
+	public AbapGitOpenViewHandler() {
+	}
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+
+		try {
+			PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().showView(AbapGitView.ID);
+		} catch (PartInitException e) {
+			e.printStackTrace();
+
+			MessageBox messageBox = new MessageBox(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
+					SWT.ICON_ERROR | SWT.OK);
+			messageBox.open();
+
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/handlers/AbapGitPullHandler.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/handlers/AbapGitPullHandler.java
@@ -1,0 +1,43 @@
+package org.abapgit.adt.ui.internal.handlers;
+
+import org.abapgit.adt.ui.internal.i18n.Messages;
+import org.abapgit.adt.ui.internal.views.AbapGitView;
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+
+public class AbapGitPullHandler extends AbstractHandler {
+
+
+	public AbapGitPullHandler() {
+	}
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+
+		try {
+			MessageBox messageBox = new MessageBox(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
+					SWT.ICON_INFORMATION | SWT.OK);
+			messageBox.setMessage(Messages.AbapGitPull_not_yet_available);
+			messageBox.open();
+
+			PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().showView(AbapGitView.ID);
+		} catch (PartInitException e) {
+			e.printStackTrace();
+
+			MessageBox messageBox = new MessageBox(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
+					SWT.ICON_ERROR | SWT.OK);
+			messageBox.setText(Messages.AbapGitView_open_error);
+			messageBox.open();
+
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/i18n/Messages.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/i18n/Messages.java
@@ -55,6 +55,9 @@ public class Messages extends NLS {
 	public static String AbapGitWizardPageRepositoryAndCredentials_validate_password_error;
 	public static String AbapGitWizardPageRepositoryAndCredentials_validate_url_error;
 	public static String AbapGitWizardPageRepositoryAndCredentials_validate_user_error;
+	public static String AbapGitView_open_error;
+	public static String AbapGitPull_not_yet_available;
+
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/i18n/messages.properties
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/i18n/messages.properties
@@ -49,3 +49,5 @@ AbapGitWizardPageRepositoryAndCredentials_title=Clone abapGit Repository
 AbapGitWizardPageRepositoryAndCredentials_validate_password_error=Please specify password
 AbapGitWizardPageRepositoryAndCredentials_validate_url_error=Please enter a valid Git URL.
 AbapGitWizardPageRepositoryAndCredentials_validate_user_error=Please specify user
+AbapGitView_open_error=AbapGit view could not be opened.  
+AbapGitPull_not_yet_available=Call of pull action can not yet be called directly from project explorer. AbapGit View will be opened instead.


### PR DESCRIPTION
First draft of project explorer integration, maybe a bit different like suggested in the issue above. 

The visibility of the two menu items is actually not ideal (currently the menu items are shown for ABAP projects but also for standard projects - did recognize this after creation of the pull request). Thus the IProject part has to be removed. The visibility part is currently duplicated three times, but I did not refactored it already as I am not sure if the visibility is not differently wanted (eg. only when an ABAP package is selected).   

If this type of integration into the project explorer is desired then a possible next step would be to get the project and package into the AbapGitPull action for example, I would do this by adding the plugin com.sap.adt.projectexplorer to the project. 

But I leave it for the moment like it is, until its clear whether this pull request fits into the overall design of this project or not. 

Let me know, Andreas 