### PR TITLE
[abapGit Repo] Use Eclipse Shared Images for repository status

### DIFF
--- a/org.abapgit.adt.backend/src/org/abapgit/adt/backend/IRepository.java
+++ b/org.abapgit.adt.backend/src/org/abapgit/adt/backend/IRepository.java
@@ -25,6 +25,15 @@ public interface IRepository {
 
 	public String getPackage();
 
+	/**
+	 * Returns a flag which indicates the repository status. </br>
+	 * </br>
+	 * <b> S : Success </br>
+	 * W : Warning </br>
+	 * E : Error </br>
+	 * A : Abort </br>
+	 * R : Running </b>
+	 */
 	public String getStatusFlag();
 
 	public String getStatusText();

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/repositories/AbapGitView.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/repositories/AbapGitView.java
@@ -287,20 +287,15 @@ public class AbapGitView extends ViewPart {
 				if (statusFlag != null) {
 					switch (statusFlag) {
 					case "W": //$NON-NLS-1$
-						return AbstractUIPlugin.imageDescriptorFromPlugin("org.eclipse.jdt.ui", "icons/full/obj16/warning_obj.png") //$NON-NLS-1$//$NON-NLS-2$
-								.createImage();
+						return PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_OBJS_WARN_TSK);
 					case "E": //$NON-NLS-1$
-						return AbstractUIPlugin.imageDescriptorFromPlugin("org.eclipse.jdt.ui", "icons/full/obj16/error_obj.png") //$NON-NLS-1$//$NON-NLS-2$
-								.createImage();
+						return PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_OBJS_ERROR_TSK);
 					case "A": //$NON-NLS-1$
-						return AbstractUIPlugin.imageDescriptorFromPlugin("org.eclipse.ui", "icons/full/elcl16/stop.png") //$NON-NLS-1$//$NON-NLS-2$
-								.createImage();
+						return PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_ELCL_STOP);
 					case "S": //$NON-NLS-1$
-						return AbstractUIPlugin.imageDescriptorFromPlugin("org.eclipse.ui", "icons/full/eview16/tasks_tsk.png") //$NON-NLS-1$//$NON-NLS-2$
-								.createImage();
+						return PlatformUI.getWorkbench().getSharedImages().getImage(org.eclipse.ui.ide.IDE.SharedImages.IMG_OBJS_TASK_TSK);
 					case "R": //$NON-NLS-1$
-						return AbstractUIPlugin.imageDescriptorFromPlugin("org.eclipse.ui", "icons/full/elcl16/up_nav.png") //$NON-NLS-1$//$NON-NLS-2$
-								.createImage();
+						return PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_TOOL_UP);
 					}
 				}
 				return null;


### PR DESCRIPTION
Use ISharedImages from eclipse.ui for repository status images instead
of using images from plugin bundles as the later is not a stable
approach.

Fixes the issue #165 