### PR TITLE
Repository Browser in AbapGit Staging View

### DIFF
--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/i18n/Messages.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/i18n/Messages.java
@@ -158,6 +158,9 @@ public class Messages extends NLS {
 	public static String AbapGitStaging_compare_objects_dialog_title;
 	public static String AbapGitStaging_compare_objects_identical_xmsg;
 	public static String AbapGitStaging_compare_not_supported_xmg;
+	public static String AbapGitStaging_switch_repository;
+	public static String AbapGitStaging_switch_repository_no_system_xmg;
+	public static String AbapGitStaging_switch_repository_no_repositories_xmsg;
 
 	static {
 		// initialize resource bundle

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/i18n/Messages.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/i18n/Messages.java
@@ -159,7 +159,7 @@ public class Messages extends NLS {
 	public static String AbapGitStaging_compare_objects_identical_xmsg;
 	public static String AbapGitStaging_compare_not_supported_xmg;
 	public static String AbapGitStaging_switch_repository;
-	public static String AbapGitStaging_switch_repository_no_system_xmg;
+	public static String AbapGitStaging_switch_repository_no_supported_systems_xmg;
 	public static String AbapGitStaging_switch_repository_no_repositories_xmsg;
 
 	static {

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/i18n/messages.properties
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/i18n/messages.properties
@@ -152,5 +152,5 @@ AbapGitStaging_compare_objects_dialog_title=Versions Comparison
 AbapGitStaging_compare_objects_identical_xmsg=Local and Remote versions of the file {0} do not differ.
 AbapGitStaging_compare_not_supported_xmg=Version comparison not supported for object {0}.
 AbapGitStaging_switch_repository=Switch Repository (from logged-on and supported systems)
-AbapGitStaging_switch_repository_no_system_xmg=(no supported systems)
+AbapGitStaging_switch_repository_no_supported_systems_xmg=(no supported systems)
 AbapGitStaging_switch_repository_no_repositories_xmsg=(no linked repositories)

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/i18n/messages.properties
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/i18n/messages.properties
@@ -151,3 +151,6 @@ AbapGitStaging_compare_job_title=Opening compare editor...
 AbapGitStaging_compare_objects_dialog_title=Versions Comparison
 AbapGitStaging_compare_objects_identical_xmsg=Local and Remote versions of the file {0} do not differ.
 AbapGitStaging_compare_not_supported_xmg=Version comparison not supported for object {0}.
+AbapGitStaging_switch_repository=Switch Repository (from logged-on and supported systems)
+AbapGitStaging_switch_repository_no_system_xmg=(no supported systems)
+AbapGitStaging_switch_repository_no_repositories_xmsg=(no linked repositories)

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/AbapGitStagingObjectMenuFactory.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/AbapGitStagingObjectMenuFactory.java
@@ -5,7 +5,6 @@ import org.abapgit.adt.ui.internal.i18n.Messages;
 import org.abapgit.adt.ui.internal.staging.actions.CompareAction;
 import org.abapgit.adt.ui.internal.staging.actions.CopyNameAction;
 import org.abapgit.adt.ui.internal.staging.actions.OpenObjectAction;
-import org.abapgit.adt.ui.internal.staging.util.AbapGitStagingService;
 import org.abapgit.adt.ui.internal.staging.util.IAbapGitStagingService;
 import org.eclipse.jface.action.IMenuListener;
 import org.eclipse.jface.action.IMenuManager;
@@ -35,11 +34,12 @@ public class AbapGitStagingObjectMenuFactory {
 	private CopyNameAction copyAction;
 	private CompareAction compareAction;
 
-	public AbapGitStagingObjectMenuFactory(TreeViewer treeViewer, boolean unstaged, AbapGitStagingView view) {
+	public AbapGitStagingObjectMenuFactory(TreeViewer treeViewer, boolean unstaged, AbapGitStagingView view,
+			IAbapGitStagingService stagingUtil) {
 		this.treeViewer = treeViewer;
 		this.view = view;
 		this.unstaged = unstaged;
-		this.stagingService = AbapGitStagingService.getInstance();
+		this.stagingService = stagingUtil;
 
 		createActions();
 

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/IAbapGitStagingView.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/IAbapGitStagingView.java
@@ -14,4 +14,16 @@ public interface IAbapGitStagingView {
 	 *            repository
 	 */
 	public void openStagingView(IRepository repository, IProject project);
+
+	/**
+	 * Returns the current repository which is loaded. Null if staging view is
+	 * not loaded with any repository
+	 */
+	public IRepository getRepository();
+
+	/**
+	 * Returns the project of the repository currently loaded. Null if no
+	 * repository has been loaded.
+	 */
+	public IProject getProject();
 }

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/actions/CompareAction.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/actions/CompareAction.java
@@ -40,7 +40,6 @@ import com.sap.adt.tools.core.project.AdtProjectServiceFactory;
 import com.sap.adt.tools.core.urimapping.AdtUriMappingServiceFactory;
 import com.sap.adt.tools.core.urimapping.UriMappingContext;
 
-@SuppressWarnings("restriction")
 public class CompareAction extends BaseSelectionListenerAction {
 	private final TreeViewer treeViewer;
 	private final IAbapGitStagingView view;

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/actions/OpenObjectAction.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/actions/OpenObjectAction.java
@@ -2,8 +2,8 @@ package org.abapgit.adt.ui.internal.staging.actions;
 
 import org.abapgit.adt.backend.model.abapgitstaging.IAbapGitObject;
 import org.abapgit.adt.ui.internal.i18n.Messages;
-import org.abapgit.adt.ui.internal.staging.AbapGitStagingView;
-import org.abapgit.adt.ui.internal.staging.util.AbapGitStagingService;
+import org.abapgit.adt.ui.internal.staging.IAbapGitStagingView;
+import org.abapgit.adt.ui.internal.util.AbapGitUIServiceFactory;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.ui.actions.BaseSelectionListenerAction;
@@ -11,9 +11,9 @@ import org.eclipse.ui.actions.BaseSelectionListenerAction;
 public class OpenObjectAction extends BaseSelectionListenerAction {
 
 	private final TreeViewer treeViewer;
-	private final AbapGitStagingView view;
+	private final IAbapGitStagingView view;
 
-	public OpenObjectAction(AbapGitStagingView view, TreeViewer treeViewer) {
+	public OpenObjectAction(IAbapGitStagingView view, TreeViewer treeViewer) {
 		super(Messages.AbapGitStaging_action_open);
 		setEnabled(updateSelection((IStructuredSelection) treeViewer.getSelection()));
 
@@ -39,7 +39,7 @@ public class OpenObjectAction extends BaseSelectionListenerAction {
 	public void run() {
 		IStructuredSelection selection = (IStructuredSelection) this.treeViewer.getSelection();
 		for (Object object : selection.toList()) {
-			AbapGitStagingService.getInstance().openEditor(object, this.view.getProject());
+			AbapGitUIServiceFactory.createAbapGitStagingService().openEditor(object, this.view.getProject());
 		}
 	}
 }

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/actions/OpenPackageAction.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/actions/OpenPackageAction.java
@@ -3,8 +3,9 @@ package org.abapgit.adt.ui.internal.staging.actions;
 import java.util.List;
 
 import org.abapgit.adt.ui.internal.i18n.Messages;
-import org.abapgit.adt.ui.internal.staging.AbapGitStagingView;
-import org.abapgit.adt.ui.internal.staging.util.AbapGitStagingService;
+import org.abapgit.adt.ui.internal.staging.IAbapGitStagingView;
+import org.abapgit.adt.ui.internal.util.AbapGitUIServiceFactory;
+import org.abapgit.adt.ui.internal.util.IAbapGitService;
 import org.eclipse.ui.actions.BaseSelectionListenerAction;
 
 import com.sap.adt.tools.core.ui.navigation.AdtNavigationServiceFactory;
@@ -13,20 +14,22 @@ import com.sap.adt.tools.core.ui.packages.IAdtPackageServiceUI;
 
 public class OpenPackageAction extends BaseSelectionListenerAction {
 
-	private final AbapGitStagingView view;
+	private final IAbapGitStagingView view;
+	private final IAbapGitService service;
 
-	public OpenPackageAction(AbapGitStagingView view) {
+	public OpenPackageAction(IAbapGitStagingView view) {
 		super(Messages.AbapGitView_action_open);
 		setToolTipText(Messages.AbapGitView_action_open_xtol);
 		setImageDescriptor(
 				com.sap.adt.tools.core.ui.Activator.getDefault().getImageDescriptor(com.sap.adt.tools.core.ui.ISharedImages.PACKAGE));
 
 		this.view = view;
+		this.service = AbapGitUIServiceFactory.createAbapGitService();
 	}
 
 	public void run() {
 		if (this.view.getRepository() != null && this.view.getProject() != null) {
-			if (!AbapGitStagingService.getInstance().isLoggedOn(this.view.getProject())) {
+			if (!this.service.ensureLoggedOn(this.view.getProject())) {
 				return;
 			}
 			openPackage();
@@ -36,7 +39,7 @@ public class OpenPackageAction extends BaseSelectionListenerAction {
 	private void openPackage() {
 		IAdtPackageServiceUI packageServiceUI = AdtPackageServiceUIFactory.getOrCreateAdtPackageServiceUI();
 		List<com.sap.adt.tools.core.model.adtcore.IAdtObjectReference> pkgRefs = packageServiceUI.find(
-				AbapGitStagingService.getInstance().getDestination(this.view.getProject()), this.view.getRepository().getPackage(), null);
+				this.service.getDestination(this.view.getProject()), this.view.getRepository().getPackage(), null);
 		if (!pkgRefs.isEmpty()) {
 			com.sap.adt.tools.core.model.adtcore.IAdtObjectReference gitPackageRef = pkgRefs.stream().findFirst().get();
 			if (gitPackageRef != null) {

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/util/AbapGitStagingService.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/util/AbapGitStagingService.java
@@ -10,6 +10,7 @@ import org.abapgit.adt.backend.model.abapgitstaging.IAbapGitFile;
 import org.abapgit.adt.backend.model.abapgitstaging.IAbapGitObject;
 import org.abapgit.adt.ui.AbapGitUIPlugin;
 import org.abapgit.adt.ui.internal.i18n.Messages;
+import org.abapgit.adt.ui.internal.util.AbapGitService;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -27,53 +28,12 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
 
-import com.sap.adt.destinations.ui.logon.AdtLogonServiceUIFactory;
 import com.sap.adt.tools.core.AdtObjectReference;
 import com.sap.adt.tools.core.IAdtObjectReference;
-import com.sap.adt.tools.core.model.atom.IAtomLink;
 import com.sap.adt.tools.core.model.util.AdtObjectReferenceAdapterFactory;
-import com.sap.adt.tools.core.project.AdtProjectServiceFactory;
 import com.sap.adt.tools.core.ui.navigation.AdtNavigationServiceFactory;
 
-public class AbapGitStagingService implements IAbapGitStagingService {
-	private static IAbapGitStagingService instance;
-
-	//singleton
-	private AbapGitStagingService() {
-	}
-
-	public static IAbapGitStagingService getInstance() {
-		if (instance == null) {
-			instance = new AbapGitStagingService();
-		}
-		return instance;
-	}
-
-	public boolean isLoggedOn(IProject project) {
-		if (AdtLogonServiceUIFactory.createLogonServiceUI().ensureLoggedOn(project).isOK()) {
-			return true;
-		}
-		return false;
-	}
-
-	public String getHrfFromAtomLink(Object object, String relation) {
-		if (object instanceof IAbapGitFile) {
-			IAbapGitFile file = (IAbapGitFile) object;
-			for (IAtomLink link : file.getLinks()) {
-				if (link.getRel().equalsIgnoreCase(relation)) {
-					return link.getHref();
-				}
-			}
-		} else if (object instanceof IAbapGitObject) {
-			IAbapGitObject abapObject = (IAbapGitObject) object;
-			for (IAtomLink link : abapObject.getLinks()) {
-				if (link.getRel().equalsIgnoreCase(relation)) {
-					return link.getHref();
-				}
-			}
-		}
-		return null;
-	}
+public class AbapGitStagingService extends AbapGitService implements IAbapGitStagingService {
 
 	public void openEditor(Object object, IProject project) {
 		if (object instanceof IAbapGitObject) {
@@ -189,10 +149,6 @@ public class AbapGitStagingService implements IAbapGitStagingService {
 		return IDEWorkbenchPlugin.DEFAULT_TEXT_EDITOR_ID;
 	}
 
-	public String getDestination(IProject project) {
-		return AdtProjectServiceFactory.createProjectService().getDestinationId(project);
-	}
-
 	@Override
 	public boolean isFileCompareSupported(Object object) {
 		return isFetchFileContentSupported(object);
@@ -212,7 +168,7 @@ public class AbapGitStagingService implements IAbapGitStagingService {
 		//Compare with remote feature is available from 2002 Abap in CP release
 		//Check if the necessary atom link is present in the model
 		//TODO remove this check once the customer upgrades to 2002 release
-		if (AbapGitStagingService.getInstance().getHrfFromAtomLink(file, IFileService.RELATION_FILE_FETCH_LOCAL) != null) {
+		if (getHrfFromAtomLink(file, IFileService.RELATION_FILE_FETCH_LOCAL) != null) {
 			return true;
 		}
 		return false;

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/util/IAbapGitStagingService.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/util/IAbapGitStagingService.java
@@ -1,34 +1,10 @@
 package org.abapgit.adt.ui.internal.staging.util;
 
 import org.abapgit.adt.backend.IFileService;
+import org.abapgit.adt.ui.internal.util.IAbapGitService;
 import org.eclipse.core.resources.IProject;
 
-public interface IAbapGitStagingService {
-	/**
-	 * Checks if the abap project is logged on
-	 *
-	 * @param project
-	 *            Project to be checked
-	 * @return Returns true if the project is logged on
-	 */
-	boolean isLoggedOn(IProject project);
-
-	/**
-	 * @return Destination Id for the given abap project
-	 */
-	String getDestination(IProject project);
-
-	/**
-	 * Returns the href from the atom link based on the relation
-	 *
-	 * @param object
-	 *            Object can be IAbapGitObject or IAbapGitFile
-	 * @param relation
-	 *            Relation of the atom link which has to be retrieved
-	 * @return Href from the atom link found or null if no atom link is present
-	 *         with the given relation
-	 */
-	String getHrfFromAtomLink(Object object, String relation);
+public interface IAbapGitStagingService extends IAbapGitService {
 
 	/**
 	 * Utility method for opening the editor for AbapGit Object and AbapGit

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/util/ProjectChangeListener.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/util/ProjectChangeListener.java
@@ -30,14 +30,17 @@ public class ProjectChangeListener implements IResourceChangeListener {
 
 	@Override
 	public void resourceChanged(IResourceChangeEvent event) {
-		IResource resource = event.getResource();
-		if (resource instanceof IProject) {
-			if (event.getType() == IResourceChangeEvent.PRE_DELETE || event.getType() == IResourceChangeEvent.PRE_CLOSE) {
-				if (this.project.equals(resource)) {
-					//reset the staging view to initial
-					Display.getDefault().syncExec(() -> ProjectChangeListener.this.view.resetStagingView());
+		if (this.view != null && this.project != null) {
+			IResource resource = event.getResource();
+			if (resource instanceof IProject) {
+				if (event.getType() == IResourceChangeEvent.PRE_DELETE || event.getType() == IResourceChangeEvent.PRE_CLOSE) {
+					if (this.project.equals(resource)) {
+						//reset the staging view to initial
+						Display.getDefault().syncExec(() -> ProjectChangeListener.this.view.resetStagingView());
+					}
 				}
 			}
 		}
 	}
+
 }

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/util/SwitchRepositoryMenuCreator.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/util/SwitchRepositoryMenuCreator.java
@@ -84,7 +84,7 @@ public class SwitchRepositoryMenuCreator implements IMenuCreator {
 		}
 		//if no logged on and supported systems are available, add a dummy menu contribution
 		if (this.menu.getItemCount() == 0) {
-			this.menuItem = new Action(Messages.AbapGitStaging_switch_repository_no_system_xmg) {
+			this.menuItem = new Action(Messages.AbapGitStaging_switch_repository_no_supported_systems_xmg) {
 			};
 			//disable the menu
 			this.menuItem.setEnabled(false);
@@ -225,8 +225,10 @@ public class SwitchRepositoryMenuCreator implements IMenuCreator {
 	private ImageDescriptor getMyRepositoryImageDescriptor() {
 		if (this.myRepositoryImageDescriptor == null) {
 			Bundle actionShowMyReposBundle = Platform.getBundle("com.sap.adt.projectexplorer.ui"); //$NON-NLS-1$
-			URL actionShowMyReposImgUrl = FileLocator.find(actionShowMyReposBundle, new Path("icons/obj/package_obj_user.png"), null); //$NON-NLS-1$
-			this.myRepositoryImageDescriptor = ImageDescriptor.createFromURL(actionShowMyReposImgUrl);
+			if (actionShowMyReposBundle != null) {
+				URL actionShowMyReposImgUrl = FileLocator.find(actionShowMyReposBundle, new Path("icons/obj/package_obj_user.png"), null); //$NON-NLS-1$
+				this.myRepositoryImageDescriptor = ImageDescriptor.createFromURL(actionShowMyReposImgUrl);
+			}
 		}
 		return this.myRepositoryImageDescriptor;
 	}

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/util/SwitchRepositoryMenuCreator.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/util/SwitchRepositoryMenuCreator.java
@@ -1,0 +1,246 @@
+package org.abapgit.adt.ui.internal.staging.util;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+import org.abapgit.adt.backend.IRepositories;
+import org.abapgit.adt.backend.IRepository;
+import org.abapgit.adt.backend.IRepositoryService;
+import org.abapgit.adt.ui.internal.i18n.Messages;
+import org.abapgit.adt.ui.internal.staging.IAbapGitStagingView;
+import org.abapgit.adt.ui.internal.util.AbapGitUIServiceFactory;
+import org.abapgit.adt.ui.internal.util.RepositoryUtil;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.ActionContributionItem;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.action.IMenuCreator;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Menu;
+import org.osgi.framework.Bundle;
+
+import com.sap.adt.project.AdtCoreProjectServiceFactory;
+import com.sap.adt.tools.core.project.IAbapProject;
+
+/**
+ * Repository Switch Menu Creator for AbapGit Staging view
+ */
+public class SwitchRepositoryMenuCreator implements IMenuCreator {
+	private final IAbapGitStagingView view;
+	private final IAbapGitStagingService stagingUtil;
+	private Menu menu;
+	private ImageDescriptor myRepositoryImageDescriptor;
+
+	private IAction menuItem;
+	private ActionContributionItem item;
+
+	//testing
+	private IRepositoryService repositoryService;
+
+	public SwitchRepositoryMenuCreator(IAbapGitStagingView view, IAbapGitStagingService stagingUtil) {
+		this.view = view;
+		this.stagingUtil = stagingUtil;
+	}
+
+	@Override
+	public Menu getMenu(Control ctrl) {
+		//dispose menu if already created
+		if (this.menu != null) {
+			this.menu.dispose();
+			this.menu = null;
+		}
+		//create new menu for the control
+		this.menu = new Menu(ctrl);
+		//Create the first level menu with the available project in the workspace
+		//-----------------------------------------------------------------------
+		//get the list of accessible projects - existing and open projects
+		IProject[] projects = AdtCoreProjectServiceFactory.createCoreProjectService().getAvailableAdtCoreProjects();
+		for (IProject project : projects) {
+			//we will show the project in the menu only if it is logged on
+			if (this.stagingUtil.isLoggedOn(project)) {
+				//check if abapgit is supported by the project
+				if (!this.stagingUtil.isAbapGitSupported(project)) {
+					//do not show projects which does not support abapgit
+					continue;
+				}
+				//create a drop down menu item for the project
+				this.menuItem = new Action(project.getName(), IAction.AS_DROP_DOWN_MENU) {
+				};
+				//add the sub menu creator for the project, which will create the menu
+				//with the list of available repositories
+				this.menuItem.setMenuCreator(new RespositoryListMenuCreator(project));
+				this.item = new ActionContributionItem(this.menuItem);
+				this.item.fill(this.menu, -1);
+			}
+		}
+		//if no logged on and supported systems are available, add a dummy menu contribution
+		if (this.menu.getItemCount() == 0) {
+			this.menuItem = new Action(Messages.AbapGitStaging_switch_repository_no_system_xmg) {
+			};
+			//disable the menu
+			this.menuItem.setEnabled(false);
+			this.item = new ActionContributionItem(this.menuItem);
+			this.item.fill(this.menu, -1);
+		}
+		return this.menu;
+	}
+
+	@Override
+	public void dispose() {
+		if (this.menu != null) {
+			this.menu.dispose();
+			this.menu = null;
+		}
+	}
+
+	@Override
+	public Menu getMenu(Menu parent) {
+		return null;
+	}
+
+	/**
+	 * Menu creator for repositories. Creates the submenu under a project menu
+	 * item with the list of repositories available in that system
+	 */
+	private class RespositoryListMenuCreator implements IMenuCreator {
+		private final IProject project;
+
+		RespositoryListMenuCreator(IProject project) {
+			this.project = project;
+		}
+
+		@Override
+		public Menu getMenu(Menu parent) {
+			//check if project is logged on
+			if (!SwitchRepositoryMenuCreator.this.stagingUtil.isLoggedOn(this.project)) {
+				return null;
+			}
+
+			//get an instance of the repository service for the
+			IRepositoryService service = getRepositoryService(this.project);
+			if (service == null) { //abapgit not supported
+				return null;
+			}
+
+			//create sub menu
+			Menu repositoryMenu = new Menu(parent);
+			//fetch the repositories available in the system
+			IRepositories repositories = service.getRepositories(new NullProgressMonitor());
+			//get the logged on user
+			String loggedOnUser = getLoggedOnUser(this.project);
+			//sort repositories
+			List<IRepository> repos = sortRepositories(repositories, loggedOnUser);
+
+			//create menu contribution for each repository
+			for (IRepository repository : repos) {
+				String repoName = RepositoryUtil.getRepoNameFromUrl(repository.getUrl());
+				SwitchRepositoryMenuCreator.this.menuItem = new Action(repoName, IAction.AS_RADIO_BUTTON) {
+					@Override
+					public void run() {
+						//open the selected repository in the staging view
+						if (!repository.equals(SwitchRepositoryMenuCreator.this.view.getRepository())) {
+							SwitchRepositoryMenuCreator.this.view.openStagingView(repository, RespositoryListMenuCreator.this.project);
+						}
+					}
+				};
+				//set an image for the menu contribution if the repository belongs to the logged on user
+				if (repository.getCreatedBy().equalsIgnoreCase(loggedOnUser)) {
+					SwitchRepositoryMenuCreator.this.menuItem.setImageDescriptor(getMyRepositoryImageDescriptor());
+				}
+				//set the linked package name as tooltip
+				SwitchRepositoryMenuCreator.this.menuItem.setToolTipText(repository.getPackage());
+				//check the current selected repository
+				if (SwitchRepositoryMenuCreator.this.view.getRepository() != null) {
+					if (SwitchRepositoryMenuCreator.this.view.getProject().equals(this.project)
+							&& repository.equals(SwitchRepositoryMenuCreator.this.view.getRepository())) {
+						SwitchRepositoryMenuCreator.this.menuItem.setChecked(true);
+					}
+				}
+				SwitchRepositoryMenuCreator.this.item = new ActionContributionItem(SwitchRepositoryMenuCreator.this.menuItem);
+				SwitchRepositoryMenuCreator.this.item.fill(repositoryMenu, -1);
+			}
+			//if no abapgit repositories are available, add a dummy menu contribution
+			if (repositoryMenu.getItemCount() == 0) {
+				SwitchRepositoryMenuCreator.this.menuItem = new Action(Messages.AbapGitStaging_switch_repository_no_repositories_xmsg) {
+				};
+				//disable the menu
+				SwitchRepositoryMenuCreator.this.menuItem.setEnabled(false);
+				SwitchRepositoryMenuCreator.this.item = new ActionContributionItem(SwitchRepositoryMenuCreator.this.menuItem);
+				SwitchRepositoryMenuCreator.this.item.fill(repositoryMenu, -1);
+			}
+			return repositoryMenu;
+		}
+
+		@Override
+		public void dispose() {
+		}
+
+		@Override
+		public Menu getMenu(Control parent) {
+			return null;
+		}
+	}
+
+	/**
+	 * Get the logged on user for the given project
+	 */
+	private String getLoggedOnUser(IProject project) {
+		IAbapProject abapProject = project.getAdapter(IAbapProject.class);
+		return abapProject.getDestinationData().getUser();
+	}
+
+	/**
+	 * Sort repositories on alphabetical order. If the repositories are from the
+	 * logged on user, it should appear on the top.
+	 */
+	private List<IRepository> sortRepositories(IRepositories repositoryList, String loggedOnUser) {
+		List<IRepository> repositories = new ArrayList<IRepository>(repositoryList.getRepositories());
+		Collections.sort(repositories, new Comparator<IRepository>() {
+			@Override
+			public int compare(IRepository repo1, IRepository repo2) {
+				if (repo1.getCreatedBy().equalsIgnoreCase(loggedOnUser) && !repo2.getCreatedBy().equalsIgnoreCase(loggedOnUser)) {
+					return -1;
+				} else if (!repo1.getCreatedBy().equalsIgnoreCase(loggedOnUser) && repo2.getCreatedBy().equalsIgnoreCase(loggedOnUser)) {
+					return 1;
+				}
+				return RepositoryUtil.getRepoNameFromUrl(repo1.getUrl()).toLowerCase(Locale.ENGLISH)
+						.compareTo(RepositoryUtil.getRepoNameFromUrl(repo2.getUrl()).toLowerCase(Locale.ENGLISH));
+			}
+		});
+		return repositories;
+	}
+
+	/**
+	 * Get image for my repositories
+	 */
+	private ImageDescriptor getMyRepositoryImageDescriptor() {
+		if (this.myRepositoryImageDescriptor == null) {
+			Bundle actionShowMyReposBundle = Platform.getBundle("com.sap.adt.projectexplorer.ui"); //$NON-NLS-1$
+			URL actionShowMyReposImgUrl = FileLocator.find(actionShowMyReposBundle, new Path("icons/obj/package_obj_user.png"), null); //$NON-NLS-1$
+			this.myRepositoryImageDescriptor = ImageDescriptor.createFromURL(actionShowMyReposImgUrl);
+		}
+		return this.myRepositoryImageDescriptor;
+	}
+
+	private IRepositoryService getRepositoryService(IProject project) {
+		if (this.repositoryService == null) {
+			return AbapGitUIServiceFactory.createRepositoryService(project);
+		}
+		return this.repositoryService;
+	}
+
+	//testing
+	public void injectRepositoryService(IRepositoryService service) {
+		this.repositoryService = service;
+	}
+
+}

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/util/AbapGitService.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/util/AbapGitService.java
@@ -1,0 +1,61 @@
+package org.abapgit.adt.ui.internal.util;
+
+import org.abapgit.adt.backend.IRepositoryService;
+import org.abapgit.adt.backend.RepositoryServiceFactory;
+import org.abapgit.adt.backend.model.abapgitstaging.IAbapGitFile;
+import org.abapgit.adt.backend.model.abapgitstaging.IAbapGitObject;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import com.sap.adt.destinations.logon.AdtLogonServiceFactory;
+import com.sap.adt.destinations.ui.logon.AdtLogonServiceUIFactory;
+import com.sap.adt.tools.core.model.atom.IAtomLink;
+import com.sap.adt.tools.core.project.AdtProjectServiceFactory;
+
+public class AbapGitService implements IAbapGitService {
+
+	@Override
+	public boolean isLoggedOn(IProject project) {
+		return AdtLogonServiceFactory.createLogonService().isLoggedOn(getDestination(project));
+	}
+
+	@Override
+	public boolean ensureLoggedOn(IProject project) {
+		if (AdtLogonServiceUIFactory.createLogonServiceUI().ensureLoggedOn(project).isOK()) {
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public String getDestination(IProject project) {
+		return AdtProjectServiceFactory.createProjectService().getDestinationId(project);
+	}
+
+	@Override
+	public String getHrfFromAtomLink(Object object, String relation) {
+		if (object instanceof IAbapGitFile) {
+			IAbapGitFile file = (IAbapGitFile) object;
+			for (IAtomLink link : file.getLinks()) {
+				if (link.getRel().equalsIgnoreCase(relation)) {
+					return link.getHref();
+				}
+			}
+		} else if (object instanceof IAbapGitObject) {
+			IAbapGitObject abapObject = (IAbapGitObject) object;
+			for (IAtomLink link : abapObject.getLinks()) {
+				if (link.getRel().equalsIgnoreCase(relation)) {
+					return link.getHref();
+				}
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public boolean isAbapGitSupported(IProject project) {
+		IRepositoryService service = RepositoryServiceFactory.createRepositoryService(getDestination(project), new NullProgressMonitor());
+		return service != null ? true : false;
+	}
+
+}

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/util/AbapGitUIServiceFactory.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/util/AbapGitUIServiceFactory.java
@@ -1,0 +1,39 @@
+package org.abapgit.adt.ui.internal.util;
+
+import org.abapgit.adt.backend.FileServiceFactory;
+import org.abapgit.adt.backend.IFileService;
+import org.abapgit.adt.backend.IRepositoryService;
+import org.abapgit.adt.backend.RepositoryServiceFactory;
+import org.abapgit.adt.ui.internal.staging.util.AbapGitStagingService;
+import org.abapgit.adt.ui.internal.staging.util.IAbapGitStagingService;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import com.sap.adt.tools.core.project.AdtProjectServiceFactory;
+
+public class AbapGitUIServiceFactory {
+
+	private AbapGitUIServiceFactory() {
+	}
+
+	public static IAbapGitService createAbapGitService() {
+		return new AbapGitService();
+	}
+
+	public static IAbapGitStagingService createAbapGitStagingService() {
+		return new AbapGitStagingService();
+	}
+
+	public static IRepositoryService createRepositoryService(IProject project) {
+		return RepositoryServiceFactory.createRepositoryService(getDestination(project), new NullProgressMonitor());
+	}
+
+	public static IFileService createFileService() {
+		return FileServiceFactory.createFileService();
+	}
+
+	private static String getDestination(IProject project) {
+		return AdtProjectServiceFactory.createProjectService().getDestinationId(project);
+	}
+
+}

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/util/IAbapGitService.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/util/IAbapGitService.java
@@ -1,0 +1,47 @@
+package org.abapgit.adt.ui.internal.util;
+
+import org.eclipse.core.resources.IProject;
+
+public interface IAbapGitService {
+	/**
+	 * Checks if the abap project is logged on
+	 *
+	 * @param project
+	 *            Project to be checked
+	 * @return Returns true if the project is logged on
+	 */
+	boolean isLoggedOn(IProject project);
+
+	/**
+	 * Logon to an abap project
+	 *
+	 * @param project
+	 *            Project to logon
+	 * @return Returns true if logon is successful, else false
+	 */
+	boolean ensureLoggedOn(IProject project);
+
+	/**
+	 * @return Destination Id for the given abap project
+	 */
+	String getDestination(IProject project);
+
+	/**
+	 * Returns the href from the atom link based on the relation
+	 *
+	 * @param object
+	 *            Object can be IAbapGitObject or IAbapGitFile
+	 * @param relation
+	 *            Relation of the atom link which has to be retrieved
+	 * @return Href from the atom link found or null if no atom link is present
+	 *         with the given relation
+	 */
+	String getHrfFromAtomLink(Object object, String relation);
+
+	/**
+	 * Checks whether the given project supports AbapGit. Currently abapGit is
+	 * enabled only for steampunk projects.
+	 */
+	boolean isAbapGitSupported(IProject project);
+
+}

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/util/RepositoryUtil.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/util/RepositoryUtil.java
@@ -1,0 +1,34 @@
+package org.abapgit.adt.ui.internal.util;
+
+public class RepositoryUtil {
+
+	private RepositoryUtil() {
+		//prevent instantiation
+	}
+
+	/**
+	 * Get repository name from repository url
+	 */
+	public static String getRepoNameFromUrl(String repoURL) {
+		if (repoURL != null && !repoURL.isEmpty()) {
+			String[] tokens = repoURL.split("/"); //$NON-NLS-1$
+			String repoName = tokens[tokens.length - 1];
+			if (repoName.endsWith(".git")) { //$NON-NLS-1$
+				repoName = repoName.replace(".git", ""); //$NON-NLS-1$ //$NON-NLS-2$
+			}
+			return repoName;
+		}
+		return null;
+	}
+
+	/**
+	 * Get the branch name from the branch reference
+	 */
+	public static String getBranchNameFromRef(String branchRef) {
+		if (branchRef != null && !branchRef.isEmpty()) {
+			String[] tokens = branchRef.split("/"); //$NON-NLS-1$
+			return tokens[tokens.length - 1];
+		}
+		return null;
+	}
+}

--- a/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/staging/TestsPdeAbapGitStaging.java
+++ b/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/staging/TestsPdeAbapGitStaging.java
@@ -108,6 +108,7 @@ public class TestsPdeAbapGitStaging {
 		Assert.assertEquals(view.commitAndPushButton.getEnabled(), false);
 	}
 	
+
 	@Test
 	public void repositorySwitchAction() throws CoreException {
 		//reset view
@@ -180,19 +181,12 @@ public class TestsPdeAbapGitStaging {
 		
 		//create menu
 		Menu menu = repoSwitchMenuCreator.getMenu(toolBar);
-		//menu item count will be 2, it contains one for project "ABAPGIT_TEST_PROJECT" and one for project "ABAPGIT_TEST_PROJECT_2"
+		//menu item count will be 1, it contains one for project "ABAPGIT_TEST_PROJECT"
 		//project "ABAPGIT_TEST_PROJECT_3" will not be part of menu as it does not support abapgit
-		Assert.assertEquals(2, menu.getItemCount());
+		//project "ABAPGIT_TEST_PROJECT_2" will not be part of menu as it is not logged on
+		Assert.assertEquals(1, menu.getItemCount());
 		
-		MenuItem menuItem = menu.getItem(1);
-		Assert.assertEquals(project_not_loggedon.getName(), menuItem.getText());
-		if(menuItem.getData() instanceof ActionContributionItem) {
-			IAction action = ((ActionContributionItem)menuItem.getData()).getAction();
-			Assert.assertEquals(IAction.AS_RADIO_BUTTON, action.getStyle());
-			Assert.assertEquals("Project not logged on yet", action.getToolTipText());
-		}
-		
-		menuItem = menu.getItem(0);
+		MenuItem menuItem = menu.getItem(0);
 		Assert.assertEquals(project.getName(), menuItem.getText());
 		if(menuItem.getData() instanceof ActionContributionItem) {
 			IAction action = ((ActionContributionItem)menuItem.getData()).getAction();
@@ -209,7 +203,6 @@ public class TestsPdeAbapGitStaging {
 			menuItem = repoMenu.getItem(0);
 			//test_repo_1 will come before abcd_repo as the owner of the repo is same as the logged on user ( my_repository )
 			Assert.assertEquals(RepositoryUtil.getRepoNameFromUrl("https://github.com/AbapGit-Push/test_repo_1"), menuItem.getText());
-			Assert.assertEquals("TEST_PACKAGE_1", menuItem.getToolTipText());
 			if(menuItem.getData() instanceof ActionContributionItem) {
 				action = ((ActionContributionItem)menuItem.getData()).getAction();
 				Assert.assertEquals(IAction.AS_RADIO_BUTTON, action.getStyle());
@@ -219,11 +212,9 @@ public class TestsPdeAbapGitStaging {
 			
 			menuItem = repoMenu.getItem(1);
 			Assert.assertEquals(RepositoryUtil.getRepoNameFromUrl("https://github.com/AbapGit-Push/abcd_repo"), menuItem.getText());
-			Assert.assertEquals("TEST_PACKAGE_3", menuItem.getToolTipText());
 			
 			menuItem = repoMenu.getItem(2);
 			Assert.assertEquals(RepositoryUtil.getRepoNameFromUrl("https://github.com/AbapGit-Push/test_repo_2"), menuItem.getText());
-			Assert.assertEquals("TEST_PACKAGE_2", menuItem.getToolTipText());
 			if(menuItem.getData() instanceof ActionContributionItem) {
 				action = ((ActionContributionItem)menuItem.getData()).getAction();
 				Assert.assertEquals(IAction.AS_RADIO_BUTTON, action.getStyle());
@@ -241,7 +232,6 @@ public class TestsPdeAbapGitStaging {
 		project_not_loggedon.delete(true, new NullProgressMonitor());
 		project_not_support_abapgit.delete(true, new NullProgressMonitor());
 	}
-	
 	
 	@Test
 	public void openPublicRepository() throws IOException {

--- a/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/staging/TestsPdeAbapGitStagingUtil.java
+++ b/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/staging/TestsPdeAbapGitStagingUtil.java
@@ -1,5 +1,10 @@
 package org.abapgit.adt.ui.internal.staging;
 
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+
+import org.abapgit.adt.backend.IRepository;
 import org.abapgit.adt.backend.model.abapgitstaging.IAbapGitCommitMessage;
 import org.abapgit.adt.backend.model.abapgitstaging.IAbapGitFile;
 import org.abapgit.adt.backend.model.abapgitstaging.IAbapGitObject;
@@ -53,9 +58,8 @@ public class TestsPdeAbapGitStagingUtil {
 		return view;
 	}
 	
-	protected IProject createDummyAbapProject() throws CoreException{
-		String projectName = "ABAPGIT_TEST_PROJECT";
-		String destinationId = "ABAPGIT_TEST_PROJECT";
+	protected IProject createDummyAbapProject(String projectName) throws CoreException{
+		String destinationId = projectName;
 		
 		IDestinationDataWritable data = AdtDestinationDataFactory.newDestinationData(destinationId);
 		data.setUser("TEST_DUMMY_USER"); 
@@ -240,5 +244,20 @@ public class TestsPdeAbapGitStagingUtil {
 		staging.getUnstagedObjects().getAbapgitobject().add(getClassMock());
 
 		return staging;
+	}
+	
+	protected IRepository getRepositoryMock(String url, String branch, String linkedPackage, String createdBy) {
+		IRepository repository = createNiceMock(IRepository.class);
+		expect(repository.getUrl()).andReturn(url).anyTimes();
+		expect(repository.getBranch()).andReturn(branch).anyTimes();
+		expect(repository.getPackage()).andReturn(linkedPackage).anyTimes();
+		expect(repository.getCreatedBy()).andReturn(createdBy).anyTimes();
+		replay(repository);
+		return repository;
+	}
+	
+	protected String getLoggedOnUser(IProject project) {
+		IAbapProject abapProject = project.getAdapter(IAbapProject.class);
+		return abapProject.getDestinationData().getUser();
 	}
 }

--- a/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/util/TestsUnitRepositoryUtil.java
+++ b/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/util/TestsUnitRepositoryUtil.java
@@ -1,0 +1,28 @@
+package org.abapgit.adt.ui.internal.util;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+
+public class TestsUnitRepositoryUtil {
+	
+	@BeforeClass
+	public static void setUp() {
+	}
+	
+	@Test
+	public void getRepoNameFromUrl() {
+		String url = "https://github.com/AbapGit-Push/test_repo_1";
+		Assert.assertEquals("test_repo_1", RepositoryUtil.getRepoNameFromUrl(url));
+		
+		url = "https://github.com/AbapGit-Push/test_repo_1.git";
+		Assert.assertEquals("test_repo_1", RepositoryUtil.getRepoNameFromUrl(url));
+	}
+	
+	@Test
+	public void getBranchNameFromRef() {
+		String branchRef = "ref/head/master";
+		Assert.assertEquals("master", RepositoryUtil.getBranchNameFromRef(branchRef));
+	}
+}

--- a/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/test/suite/AllUnitTests.java
+++ b/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/test/suite/AllUnitTests.java
@@ -1,0 +1,13 @@
+package org.abapgit.adt.ui.test.suite;
+
+import org.abapgit.adt.ui.internal.util.TestsUnitRepositoryUtil;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({//
+	TestsUnitRepositoryUtil.class
+})
+public class AllUnitTests {
+
+}


### PR DESCRIPTION
New **repository browser** toolbar action in **abapgit staging view**, for easier switching to any abapgit repositories from supported abap projects added in ADT.
Previously we had to open abapgit repositories view for an abap project and had to open the staging view for the repository we wanted to open. Now directly from staging view, switching to a different repository would be possible.


Additional Changes:
- Better service and utility classes handling for abapgit