### PR TITLE
[agit staging] Fix "switch repository" bug opening same repo in diff project

### DIFF
--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/util/SwitchRepositoryMenuCreator.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/staging/util/SwitchRepositoryMenuCreator.java
@@ -147,7 +147,8 @@ public class SwitchRepositoryMenuCreator implements IMenuCreator {
 					@Override
 					public void run() {
 						//open the selected repository in the staging view
-						if (!repository.equals(SwitchRepositoryMenuCreator.this.view.getRepository())) {
+						if (!RespositoryListMenuCreator.this.project.equals(SwitchRepositoryMenuCreator.this.view.getProject())
+								|| !repository.equals(SwitchRepositoryMenuCreator.this.view.getRepository())) {
 							SwitchRepositoryMenuCreator.this.view.openStagingView(repository, RespositoryListMenuCreator.this.project);
 						}
 					}


### PR DESCRIPTION
Fixes the bug with **Switch Repositories** in abapGit staging view with
opening the same repository linked in different abap projects.