### PR TITLE
revert the changes for improved handling  transport page in link wizard

### DIFF
--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/wizards/AbapGitWizard.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/wizards/AbapGitWizard.java
@@ -80,16 +80,6 @@ public class AbapGitWizard extends Wizard {
 	@Override
 	public boolean performFinish() {
 
-		//validate input if pageBranchAndPackage finished early
-		if (getContainer().getCurrentPage() == this.pageBranchAndPackage && !this.pageBranchAndPackage.validateAll()) {
-			return false;
-		}
-
-		//validate input if pageApack finished early
-		if (getContainer().getCurrentPage() == this.pageApack && !this.pageApack.validateAll()) {
-			return false;
-		}
-
 		List<IAbapObject> cloneObjects = new LinkedList<>();
 
 		try {
@@ -252,24 +242,6 @@ public class AbapGitWizard extends Wizard {
 			return super.getNextPage(page);
 		}
 
-	}
-
-	@Override
-	public boolean canFinish() {
-		if (getContainer().getCurrentPage() == this.pageBranchAndPackage && this.pageBranchAndPackage.canFinishEarly()) {
-			return true;
-		}
-
-		if (getContainer().getCurrentPage() == this.pageApack && this.pageApack.canFinishEarly()) {
-			return true;
-		}
-
-		return super.canFinish();
-	}
-
-	//If a pull is to be done after link.
-	public boolean linkAndPull() {
-		return this.pageBranchAndPackage.getLnpSequence();
 	}
 
 	private IRepository createRepository(String url, String branch, String targetPackage, String transportRequest, String userName,

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/wizards/AbapGitWizardPageApack.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/wizards/AbapGitWizardPageApack.java
@@ -352,28 +352,4 @@ public class AbapGitWizardPageApack extends WizardPage {
 		return true;
 	}
 
-	@Override
-	public boolean canFlipToNextPage() {
-		if (!this.pullScenario) {
-			if (getWizard() instanceof AbapGitWizard && ((AbapGitWizard) getWizard()).linkAndPull()) {
-				return true;
-			} else {
-				return false;
-			}
-		}
-		return super.canFlipToNextPage();
-
-	}
-
-	public boolean canFinishEarly() {
-		if (!this.pullScenario) {
-			if (getWizard() instanceof AbapGitWizard && ((AbapGitWizard) getWizard()).linkAndPull()) {
-				return false;
-			} else {
-				return true;
-			}
-		}
-		return false;
-	}
-
 }

--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/wizards/AbapGitWizardPageBranchAndPackage.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/wizards/AbapGitWizardPageBranchAndPackage.java
@@ -382,35 +382,6 @@ public class AbapGitWizardPageBranchAndPackage extends WizardPage {
 		}
 	}
 
-	@Override
-	public boolean canFlipToNextPage() {
-
-		if (!this.pullAction) {
-			if ((getLnpSequence() || this.cloneData.hasDependencies())
-					&& validateClientOnly()) {
-				return true;
-			} else {
-				return false;
-			}
-		}
-		return super.canFlipToNextPage();
-	}
-
-	public boolean canFinishEarly() {
-
-		if (!this.pullAction) {
-			if (!getLnpSequence() && !this.cloneData.hasDependencies()
-					&& validateClientOnly()) {
-				return true;
-			} else {
-				return false;
-			}
-		} else {
-			return false;
-		}
-
-	}
-
 	private static class ApackParameters {
 
 		public String url;


### PR DESCRIPTION
In case a pull action is not performed while linking a repository,
the transport page is skipped in the link a repository wizard.
Currently, a back-end check happens for transport request for the
package provided while linking the repository, which breaks the client.
This check is not required.

Thus until the check is removed from the back end, the changes related
to skipping transport page if a link is performed without pull, have to
be reverted.