### PR TITLE
Disable selective pull feature temporarily

### DIFF
--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/util/AbapGitService.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/util/AbapGitService.java
@@ -59,15 +59,19 @@ public class AbapGitService implements IAbapGitService {
 		return service != null ? true : false;
 	}
 
-	//TODO: Remove after 2105 back end release supporting selective pull reaches all customers	
+	//TODO: Remove after 2105 back end release supporting selective pull reaches all customers
 	@Override
 	public boolean isSelectivePullSupported(IRepository repository) {
+		/*
+		 * Disable the selective pull temporarily because of the incident https://support.wdf.sap.corp/sap/support/message/2170159859. 
+		 * Selective pull backend call runs into error while PULL as it somehow involves package creation which requires a transport request to be passed on.
+		 */
 
-		for (IAtomLink link : repository.getLinks()) {
-			if (link.getRel().equalsIgnoreCase(IRepositoryService.RELATION_MODIFIED_OBJECTS)) {
-				return true;
-			}
-		}
+//		for (IAtomLink link : repository.getLinks()) {
+//			if (link.getRel().equalsIgnoreCase(IRepositoryService.RELATION_MODIFIED_OBJECTS)) {
+//				return true;
+//			}
+//		}
 		return false;
 	}
 


### PR DESCRIPTION
Backend call to fetch locally modified objects in a repository during
PULL is running into an error which results in PULL action being
aborted.

Happens while linking and pulling existing abapGit repositories which
also contains a sub-package.

Reason for the failure:
Selective pull backend call would try to create sub-packages in the
system which are part of the repository and this would require a
transport request which is currently not being passed.

A proper fix would be to handle the transport request with selective
pull backend call which would be done as a separate fix.