### PR TITLE
Display full name along with userID in abapGit repositories view

### DIFF
--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/repositories/AbapGitView.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/repositories/AbapGitView.java
@@ -98,6 +98,8 @@ import com.sap.adt.tools.core.project.IAbapProject;
 import com.sap.adt.tools.core.ui.navigation.AdtNavigationServiceFactory;
 import com.sap.adt.tools.core.ui.packages.AdtPackageServiceUIFactory;
 import com.sap.adt.tools.core.ui.packages.IAdtPackageServiceUI;
+import com.sap.adt.tools.core.ui.userinfo.AdtUserInfoFormatterFactory;
+import com.sap.adt.tools.core.ui.userinfo.IAdtUserInfoFormatter;
 
 public class AbapGitView extends ViewPart implements IAbapGitRepositoriesView {
 
@@ -754,6 +756,11 @@ public class AbapGitView extends ViewPart implements IAbapGitRepositoriesView {
 
 		if (lastChangedBy == null || lastChangedBy.isEmpty()) {
 			lastChangedBy = repo.getCreatedBy();
+
+			// format the user name to display the full name along with the user id
+			String destinationId = AbapGitView.this.abapGitService.getDestination(AbapGitView.this.lastProject);
+			lastChangedBy = AdtUserInfoFormatterFactory.createAdtUserInfoFormatter().format(new NullProgressMonitor(), destinationId,
+					lastChangedBy, IAdtUserInfoFormatter.FormatStyle.ID_AND_USERNAME_IN_BRACKETS);
 		}
 		return lastChangedBy;
 	}


### PR DESCRIPTION
abapGit repositories view currently displays the user id(SAP name) in
the
user column if in case user email is not available.

In such cases, enhance the user Id information with the full name of the
user, to be displayed, which improves the user experience.