### PR TITLE
Fix for issue 227

### DIFF
--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/wizards/AbapGitWizardSelectivePullAfterLink.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/wizards/AbapGitWizardSelectivePullAfterLink.java
@@ -53,6 +53,10 @@ public class AbapGitWizardSelectivePullAfterLink extends Wizard {
 
 		fetchModifiedObjectsinCloneData(); //fetch the modified objects for repository and its dependencies
 
+		//If no modified objects, set message
+		if (this.cloneData.repoToModifiedOverwriteObjects.isEmpty() && this.cloneData.repoToModifiedPackageWarningObjects.isEmpty()) {
+			getContainer().getCurrentPage().setDescription("No modified objects. All objects will be pulled."); //$NON-NLS-1$
+		}
 		setWindowTitle(Messages.AbapGitWizardPull_title);
 		setNeedsProgressMonitor(true);
 		setDefaultPageImageDescriptor(


### PR DESCRIPTION
1. Refactored opening of selective pull wizard after link from abapgitview to abapgitwizard

2. In case the linked repository is not retrieved, the pull after link is not performed