### PR TITLE
New release v1.7.2

### DIFF
--- a/org.abapgit.adt.backend/META-INF/MANIFEST.MF
+++ b/org.abapgit.adt.backend/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.abapgit.adt.backend;singleton:=true
-Bundle-Version: 1.7.1
+Bundle-Version: 1.7.2
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.abapgit.adt.backend/pom.xml
+++ b/org.abapgit.adt.backend/pom.xml
@@ -3,14 +3,14 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.abapgit.adt.backend</artifactId>
   <groupId>org.abapgit.adt</groupId>
-  <version>1.7.1</version>
+  <version>1.7.2</version>
   <name>org.abapgit.adt.backend</name>
   <packaging>eclipse-plugin</packaging>
 
   <parent>
     <artifactId>org.abapgit.adt.parent</artifactId>
     <groupId>org.abapgit.adt</groupId>
-    <version>1.7.1</version>
+    <version>1.7.2</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/org.abapgit.adt.feature/feature.xml
+++ b/org.abapgit.adt.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.abapgit.adt.feature"
       label="abapGit for ABAP Development Tools (ADT)"
-      version="1.7.1">
+      version="1.7.2">
 
    <description url="http://abapgit.org">
       abapGit plugin for ABAP Development Tools (ADT)

--- a/org.abapgit.adt.feature/pom.xml
+++ b/org.abapgit.adt.feature/pom.xml
@@ -3,14 +3,14 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.abapgit.adt.feature</artifactId>
   <groupId>org.abapgit.adt</groupId>
-  <version>1.7.1</version>
+  <version>1.7.2</version>
   <name>org.abapgit.adt.feature</name>
   <packaging>eclipse-feature</packaging>
 
   <parent>
     <artifactId>org.abapgit.adt.parent</artifactId>
     <groupId>org.abapgit.adt</groupId>
-    <version>1.7.1</version>
+    <version>1.7.2</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/org.abapgit.adt.ui/META-INF/MANIFEST.MF
+++ b/org.abapgit.adt.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.abapgit.adt.ui;singleton:=true
-Bundle-Version: 1.7.1
+Bundle-Version: 1.7.2
 Bundle-Activator: org.abapgit.adt.ui.AbapGitUIPlugin
 Bundle-ClassPath: .
 Bundle-Localization: plugin

--- a/org.abapgit.adt.ui/pom.xml
+++ b/org.abapgit.adt.ui/pom.xml
@@ -3,14 +3,14 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.abapgit.adt.ui</artifactId>
   <groupId>org.abapgit.adt</groupId>
-  <version>1.7.1</version>
+  <version>1.7.2</version>
   <name>org.abapgit.adt.ui</name>
   <packaging>eclipse-plugin</packaging>
 
   <parent>
     <artifactId>org.abapgit.adt.parent</artifactId>
     <groupId>org.abapgit.adt</groupId>
-    <version>1.7.1</version>
+    <version>1.7.2</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/org.abapgit.adt.updatesite/pom.xml
+++ b/org.abapgit.adt.updatesite/pom.xml
@@ -2,14 +2,14 @@
 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.abapgit.adt.updatesite</artifactId>
-  <version>1.7.1</version>
+  <version>1.7.2</version>
   <name>abapGit for ABAP Development Tools (ADT)</name>
   <packaging>eclipse-repository</packaging>
 
   <parent>
     <artifactId>org.abapgit.adt.parent</artifactId>
     <groupId>org.abapgit.adt</groupId>
-    <version>1.7.1</version>
+    <version>1.7.2</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.abapgit.adt</groupId>
   <artifactId>org.abapgit.adt.parent</artifactId>
-  <version>1.7.1</version>
+  <version>1.7.2</version>
   <name>abapGit</name>
   <packaging>pom</packaging>
   <modules>

--- a/test/org.abapgit.adt.backend.test/META-INF/MANIFEST.MF
+++ b/test/org.abapgit.adt.backend.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Unit Tests for abapGit ADT Backend components
 Bundle-SymbolicName: org.abapgit.adt.backend.test;singleton:=true
-Bundle-Version: 1.7.1
+Bundle-Version: 1.7.2
 Bundle-ClassPath: .
 Bundle-Vendor: abapGit
 Fragment-Host: org.abapgit.adt.backend

--- a/test/org.abapgit.adt.backend.test/pom.xml
+++ b/test/org.abapgit.adt.backend.test/pom.xml
@@ -2,13 +2,13 @@
 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.abapgit.adt.backend.test</artifactId>
-  <version>1.7.1</version>
+  <version>1.7.2</version>
   <name>org.abapgit.adt.backend.test</name>
   <packaging>eclipse-test-plugin</packaging>
   <parent>
     <groupId>org.abapgit.adt</groupId>
     <artifactId>tests</artifactId>
-    <version>1.7.1</version>
+    <version>1.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 </project>

--- a/test/org.abapgit.adt.ui.test/META-INF/MANIFEST.MF
+++ b/test/org.abapgit.adt.ui.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: AbapGit UI tests
 Bundle-SymbolicName: org.abapgit.adt.ui.test;singleton:=true
-Bundle-Version: 1.7.1
+Bundle-Version: 1.7.2
 Bundle-ClassPath: .
 Bundle-Vendor: abapGit
 Fragment-Host: org.abapgit.adt.ui;bundle-version="0.13.2"

--- a/test/org.abapgit.adt.ui.test/pom.xml
+++ b/test/org.abapgit.adt.ui.test/pom.xml
@@ -3,13 +3,13 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <modelVersion>4.0.0</modelVersion>
   <artifactId>org.abapgit.adt.ui.test</artifactId>
   <groupId>org.abapgit.adt</groupId>
-  <version>1.7.1</version>
+  <version>1.7.2</version>
   <name>org.abapgit.adt.ui.test</name>
   <packaging>eclipse-test-plugin</packaging>
   <parent>
     <groupId>org.abapgit.adt</groupId>
     <artifactId>tests</artifactId>
-    <version>1.7.1</version>
+    <version>1.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.abapgit.adt</groupId>
   <artifactId>tests</artifactId>
-  <version>1.7.1</version>
+  <version>1.7.2</version>
   <name>Test Fragments</name>
   <packaging>pom</packaging>
   <description>Test Fragments</description>
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.abapgit.adt</groupId>
     <artifactId>org.abapgit.adt.parent</artifactId>
-    <version>1.7.1</version>
+    <version>1.7.2</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
- Handle 401 errors from backend and ask for personal access token again during staging.

- Fix selective pull page for modified objects in linked package. This page was wrongly displaying objects from other packages.

- Update the order of items in group by option for staging view