### PR TITLE
Remove usage of integration test util classes from SAP

### DIFF
--- a/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/repositories/TestsIntegrationRepositoriesView.java
+++ b/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/repositories/TestsIntegrationRepositoriesView.java
@@ -23,19 +23,17 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import com.sap.adt.communication.resources.ResourceException;
-import com.sap.adt.test.services.destinations.DestinationTestUtil;
-import com.sap.adt.test.services.suites.AdtIntegrationTest;
-import com.sap.adt.test.services.suites.RunWithDestination;
+//import com.sap.adt.test.services.destinations.DestinationTestUtil;
+//import com.sap.adt.test.services.suites.AdtIntegrationTest;
+//import com.sap.adt.test.services.suites.RunWithDestination;
 import com.sap.adt.tools.core.model.atom.IAtomFactory;
 import com.sap.adt.tools.core.model.atom.IAtomLink;
 import com.sap.adt.tools.core.project.IAbapProject;
 import com.sap.adt.tools.core.test.services.AdtIntegrationTestProjectUtil;
 
-@RunWith(AdtIntegrationTest.class)
-@RunWithDestination(DestinationTestUtil.HTTP_SKS)
+//@RunWith(AdtIntegrationTest.class)
+//@RunWithDestination(DestinationTestUtil.HTTP_SKS)
 public class TestsIntegrationRepositoriesView {
 	private static String   destinationId;
 	private static IProject testProject;
@@ -176,15 +174,15 @@ public class TestsIntegrationRepositoriesView {
 	
 	@Test
 	public void smokeTestBranchInfo() {
-//		if(externalRepoService != null) {
-//			try {
-//				IRepository repo = createRepoWithInvalidDetails();
-//				externalRepoService.getBranchInfo(getExternalRepoInfoObject(), repo.getUrl(), repo.getRemoteUser(), repo.getRemotePassword(), repo.getBranchName(), repo.getPackage());
-//				assertFalse("Malformed URL exception expected", true);
-//			}  catch (ResourceException e) {
-//				assertResponseForInvalidURL(e);
-//			}
-//		}
+		if(externalRepoService != null) {
+			try {
+				IRepository repo = createRepoWithInvalidDetails();
+				externalRepoService.getBranchInfo(getExternalRepoInfoObject(), repo.getUrl(), repo.getRemoteUser(), repo.getRemotePassword(), repo.getBranchName(), repo.getPackage());
+				assertFalse("Malformed URL exception expected", true);
+			}  catch (ResourceException e) {
+				assertResponseForInvalidURL(e);
+			}
+		}
 	}
 
 	@Test

--- a/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/staging/TestsIntegrationStagingView.java
+++ b/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/staging/TestsIntegrationStagingView.java
@@ -32,19 +32,17 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import com.sap.adt.communication.resources.ResourceException;
-import com.sap.adt.test.services.destinations.DestinationTestUtil;
-import com.sap.adt.test.services.suites.AdtIntegrationTest;
-import com.sap.adt.test.services.suites.RunWithDestination;
+//import com.sap.adt.test.services.destinations.DestinationTestUtil;
+//import com.sap.adt.test.services.suites.AdtIntegrationTest;
+//import com.sap.adt.test.services.suites.RunWithDestination;
 import com.sap.adt.tools.core.model.atom.IAtomFactory;
 import com.sap.adt.tools.core.model.atom.IAtomLink;
 import com.sap.adt.tools.core.project.IAbapProject;
 import com.sap.adt.tools.core.test.services.AdtIntegrationTestProjectUtil;
 
-@RunWith(AdtIntegrationTest.class)
-@RunWithDestination(DestinationTestUtil.HTTP_SKS)
+//@RunWith(AdtIntegrationTest.class)
+//@RunWithDestination(DestinationTestUtil.HTTP_SKS)
 public class TestsIntegrationStagingView {
 	private static String   destinationId;
 	private static IProject testProject;

--- a/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/test/suite/AllIntegrationTests.java
+++ b/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/test/suite/AllIntegrationTests.java
@@ -3,18 +3,15 @@ package org.abapgit.adt.ui.test.suite;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-import com.sap.adt.test.services.destinations.DestinationTestUtil;
-import com.sap.adt.test.services.suites.AdtIntegrationTestSuite;
-import com.sap.adt.test.services.suites.RunWithDestination;
 import org.abapgit.adt.ui.internal.repositories.*;
 import org.abapgit.adt.ui.internal.staging.TestsIntegrationStagingView;
 
-@RunWith(AdtIntegrationTestSuite.class)
-@RunWithDestination(DestinationTestUtil.HTTP_SKS)
-@Suite.SuiteClasses({//
-	TestsIntegrationRepositoriesView.class,
-	TestsIntegrationStagingView.class
-})
-
-public class AllIntegrationTests {
-}
+//@RunWith(AdtIntegrationTestSuite.class)
+//@RunWithDestination(DestinationTestUtil.HTTP_SKS)
+//@Suite.SuiteClasses({//
+//	TestsIntegrationRepositoriesView.class,
+//	TestsIntegrationStagingView.class
+//})
+//
+//public class AllIntegrationTests {
+//}


### PR DESCRIPTION
- For added integration test using test util classes from SAP is invalid. This leads to bundling issues.