### PR TITLE
fix issue where repo was getting linked with package that does not exist

### DIFF
--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/wizards/AbapGitWizardPageBranchAndPackage.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/wizards/AbapGitWizardPageBranchAndPackage.java
@@ -253,7 +253,8 @@ public class AbapGitWizardPageBranchAndPackage extends WizardPage {
 						if (packageServiceUI.packageExists(AbapGitWizardPageBranchAndPackage.this.destination, packageName, monitor)) {
 							List<IAdtObjectReference> packageRefs = packageServiceUI
 									.find(AbapGitWizardPageBranchAndPackage.this.destination, packageName, monitor);
-							AbapGitWizardPageBranchAndPackage.this.cloneData.packageRef = packageRefs.stream().findFirst().orElse(null);
+							AbapGitWizardPageBranchAndPackage.this.cloneData.packageRef = packageRefs.stream()
+									.filter((p) -> p.getName().equalsIgnoreCase(packageName)).findFirst().orElse(null);
 						}
 					}
 				});


### PR DESCRIPTION
- ABAP package service returns the first package that matches user input package as prefix
- Thus fix should be provided by ABAP package service
- The issue is fixed from abapGIT by additionally checking if the user input matches the package returned by package service