### PR TITLE
Change the password encoder to basic instead of MIME based encoding

### DIFF
--- a/org.abapgit.adt.backend/src/org/abapgit/adt/backend/internal/RepositoryService.java
+++ b/org.abapgit.adt.backend/src/org/abapgit/adt/backend/internal/RepositoryService.java
@@ -215,7 +215,7 @@ public class RepositoryService implements IRepositoryService {
 		IHeaders headers = HeadersFactory.newHeaders();
 		IHeaders.IField userField = HeadersFactory.newField("Username", username); //$NON-NLS-1$
 		headers.addField(userField);
-		Base64.Encoder encoder = Base64.getMimeEncoder();
+		Base64.Encoder encoder = Base64.getEncoder();
 		IHeaders.IField passwordField = HeadersFactory.newField("Password", //$NON-NLS-1$
 				encoder.encodeToString(password.getBytes(StandardCharsets.UTF_8)));
 		headers.addField(passwordField);


### PR DESCRIPTION
- MIME based Base64 encoding adds a new line if the characters in encoding string are more than 76
- Since backend uses a basic Base64 decoder, the password encoding on client is updated to basic Base64 encoder.