### PR TITLE
Open Repository in ext browser with linked branch

### DIFF
--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/repositories/actions/OpenRepositoryAction.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/repositories/actions/OpenRepositoryAction.java
@@ -22,8 +22,8 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
  * Action to "Open repository in an external browser"
  */
 public class OpenRepositoryAction extends Action {
-	private static final String REFS_HEADS = "refs/heads/"; //$NON-NLS-1$
 	private final IViewPart view;
+	private static final String REFS_HEADS = "refs/heads/"; //$NON-NLS-1$
 	private static final String GITHUB_DOMAIN = "github.com"; //$NON-NLS-1$
 	private static final String GITLAB_DOMAIN = "gitlab.com"; //$NON-NLS-1$
 	private static final String GITHUB_WDF_SAP_DOMAIN = "github.wdf.sap.corp"; //$NON-NLS-1$
@@ -44,7 +44,6 @@ public class OpenRepositoryAction extends Action {
 
 	@Override
 	public void run() {
-
 		IRepository repository = getRepository();
 		if (repository != null) {
 			try {
@@ -64,14 +63,12 @@ public class OpenRepositoryAction extends Action {
 
 	public String getLink(IRepository repository) throws URISyntaxException {
 		// Get Connected branch
-		URI repoURI;
 		String repoLink = repository.getUrl();
-		String branch;
-		repoURI = new URI(repository.getUrl());
+		URI repoURI = new URI(repository.getUrl());
 		String domain = repoURI.getHost();
-		// Remove the username and `.git` suffix
 		String path = getPath(repoURI);
-		branch = repository.getBranchName();
+		String branch = repository.getBranchName();
+
 		if (isGithubDomain(domain) || isGitlabDomain(domain)) {
 			branch = branch.replace(REFS_HEADS, "/tree/"); //$NON-NLS-1$
 			repoLink = constructRepoBranchURI(repoURI, path + branch);
@@ -85,8 +82,8 @@ public class OpenRepositoryAction extends Action {
 
 	// method to construct URI from repository URI with new path and branch details
 	private String constructRepoBranchURI(URI repoURI, String path) throws URISyntaxException {
-		URI bucketURI = new URI(repoURI.getScheme(), null, repoURI.getHost(), repoURI.getPort(), path, null, null); // not taking the username for the link
-		return bucketURI.toString();
+		URI reconstructedRepoURI = new URI(repoURI.getScheme(), null, repoURI.getHost(), repoURI.getPort(), path, null, null); // not taking the username for the link
+		return reconstructedRepoURI.toString();
 	}
 
 	// method to check if the domain is a github domain

--- a/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/repositories/TestsPdeAbapGitRepositoriesUtil.java
+++ b/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/repositories/TestsPdeAbapGitRepositoriesUtil.java
@@ -1,5 +1,7 @@
 package org.abapgit.adt.ui.internal.repositories;
 
+import org.abapgit.adt.backend.model.abapgitrepositories.IRepository;
+import org.abapgit.adt.backend.model.abapgitrepositories.impl.AbapgitrepositoriesFactoryImpl;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRunnable;
@@ -82,6 +84,17 @@ public class TestsPdeAbapGitRepositoriesUtil {
 			} catch (Exception e) {
 			}
 		}
+	}
+	
+	public IRepository createDummyRepository() {
+		IRepository dummy = AbapgitrepositoriesFactoryImpl.eINSTANCE.createRepository();
+		dummy.setUrl("https://github.com/dummy_url");
+		dummy.setPackage("$AP_GITHUB");
+		dummy.setCreatedEmail("dummy_user_one@email.com");
+		dummy.setBranchName("refs/heads/master");
+		dummy.setDeserializedAt("20200322180503");
+		dummy.setStatusText("dummy_status");
+		return dummy;
 	}
 
 }

--- a/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/repositories/actions/TestUnitAbapGitRepositoriesOpenAction.java
+++ b/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/repositories/actions/TestUnitAbapGitRepositoriesOpenAction.java
@@ -1,0 +1,50 @@
+package org.abapgit.adt.ui.internal.repositories.actions;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.Assert;
+
+import java.net.URISyntaxException;
+
+import org.abapgit.adt.backend.model.abapgitrepositories.IRepository;
+import org.abapgit.adt.backend.model.abapgitrepositories.impl.AbapgitrepositoriesFactoryImpl;
+import org.abapgit.adt.ui.internal.repositories.AbapGitView;
+import org.abapgit.adt.ui.internal.repositories.TestsPdeAbapGitRepositoriesUtil;
+import org.eclipse.core.runtime.CoreException;
+
+public class TestUnitAbapGitRepositoriesOpenAction {
+
+	private static OpenRepositoryAction openAction;
+	private static AbapGitView view;
+	private static IRepository dummyGitSelection;
+	private static IRepository dummyBitSelection;
+	private static TestsPdeAbapGitRepositoriesUtil utils;
+	
+	@BeforeClass
+	public static void setup() throws CoreException {
+		utils = new TestsPdeAbapGitRepositoriesUtil();
+		view = utils.initializeView();
+		// git based host
+		dummyGitSelection = utils.createDummyRepository();
+		// bitbucket host
+		dummyBitSelection = AbapgitrepositoriesFactoryImpl.eINSTANCE.createRepository();
+		dummyBitSelection.setUrl("https://user1234@bitbucket.org/user1234/dummy.git");
+		dummyBitSelection.setPackage("$AP_GITHUB");
+		dummyBitSelection.setCreatedEmail("dummy_user_one@email.com");
+		dummyBitSelection.setBranchName("refs/heads/master");
+		dummyBitSelection.setDeserializedAt("20200322180503");
+		dummyBitSelection.setStatusText("dummy_status");
+		openAction = new OpenRepositoryAction(view);
+	}
+	
+	@Test
+	public void testOpenRepositoryInBrowserAction() throws URISyntaxException {
+		String actualGitLink = openAction.getLink(dummyGitSelection);
+		String expectedGitLink = "https://github.com/dummy_url/tree/master";
+		Assert.assertEquals(actualGitLink, expectedGitLink);
+		
+		String actualBitLink = openAction.getLink(dummyBitSelection);
+		String expectedBitLink = "https://bitbucket.org/user1234/dummy/src/master";
+		Assert.assertEquals(actualBitLink, expectedBitLink);
+	}
+}


### PR DESCRIPTION
# Workflow update:

## Earlier:
- On invoking **openRepositoryAction** the repository link is opened in default external browser

## Now
- On invoking **openRepositoryAction** link to open in browser link is generated using combination of branch linked to package and repoLink.
- Removed deprecated URL generation 