### PR TITLE
open repository in external browser with branch

### DIFF
--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/repositories/actions/OpenRepositoryAction.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/repositories/actions/OpenRepositoryAction.java
@@ -1,7 +1,8 @@
 package org.abapgit.adt.ui.internal.repositories.actions;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import org.abapgit.adt.backend.model.abapgitrepositories.IRepository;
 import org.abapgit.adt.ui.AbapGitUIPlugin;
@@ -22,6 +23,13 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
  */
 public class OpenRepositoryAction extends Action {
 	private final IViewPart view;
+	private static final String REFS_HEADS = "refs/heads/"; //$NON-NLS-1$
+	private static final String GITHUB_DOMAIN = "github.com"; //$NON-NLS-1$
+	private static final String GITLAB_DOMAIN = "gitlab.com"; //$NON-NLS-1$
+	private static final String GITHUB_WDF_SAP_DOMAIN = "github.wdf.sap.corp"; //$NON-NLS-1$
+	private static final String GITHUB_INFRA_HANA_DOMAIN = "github.infra.hana.ondemand.com"; //$NON-NLS-1$
+	private static final String GITHUB_TOOLS_DOMAIN = "github.tools.sap"; //$NON-NLS-1$
+	private static final String BIT_BUCKET_DOMAIN = "bitbucket.org"; //$NON-NLS-1$
 
 	/**
 	 * @param view
@@ -39,15 +47,75 @@ public class OpenRepositoryAction extends Action {
 		IRepository repository = getRepository();
 		if (repository != null) {
 			try {
-				// Open default external browser
-				PlatformUI.getWorkbench().getBrowserSupport().getExternalBrowser().openURL(new URL(repository.getUrl()));
-			} catch (PartInitException | MalformedURLException exception) {
+				// Get Repository link
+				String repoLink = getLink(repository);
+				// Open the link in default external browser
+				URI repositoryUri = new URI(repoLink);
+				PlatformUI.getWorkbench().getBrowserSupport().getExternalBrowser().openURL(repositoryUri.toURL());
+			} catch (PartInitException | MalformedURLException | URISyntaxException exception) {
 				MessageDialog.openError(this.view.getViewSite().getShell(), Messages.AbapGitView_action_open_repo_error_dialog_title,
 						exception.getMessage());
 				AbapGitUIPlugin.getDefault().getLog()
 						.log(new Status(IStatus.ERROR, AbapGitUIPlugin.PLUGIN_ID, exception.getMessage(), exception));
 			}
 		}
+	}
+
+	public String getLink(IRepository repository) throws URISyntaxException {
+		// Get Connected branch
+		String repoLink = repository.getUrl();
+		URI repoURI = new URI(repository.getUrl());
+		String domain = repoURI.getHost();
+		String path = getPath(repoURI);
+		String branch = repository.getBranchName();
+		if (isGithubDomain(domain) || isGitlabDomain(domain)) {
+			branch = branch.replace(REFS_HEADS, "/tree/"); //$NON-NLS-1$
+			repoLink = constructRepoBranchURI(repoURI, path + branch);
+		} else if (isBitbucketDomain(domain)) {
+			branch = branch.replace(REFS_HEADS, "/src/"); //$NON-NLS-1$
+			repoLink = constructRepoBranchURI(repoURI, path + branch);
+		}
+		// return the concatenated link that redirects to the branch
+		return repoLink;
+	}
+
+	// method to construct URI from repository URI with new path and branch details
+	private String constructRepoBranchURI(URI repoURI, String path) throws URISyntaxException {
+		URI reconstructedRepoURI = new URI(repoURI.getScheme(), null, repoURI.getHost(), repoURI.getPort(), path, null, null); // not taking the username for the link
+		return reconstructedRepoURI.toString();
+	}
+
+	// method to check if the domain is a github domain
+	private boolean isGithubDomain(String domain) {
+		if (domain.equals(GITHUB_DOMAIN) || domain.equals(GITHUB_TOOLS_DOMAIN) || domain.equals(GITHUB_INFRA_HANA_DOMAIN)
+				|| domain.equals(GITHUB_WDF_SAP_DOMAIN)) {
+			return true;
+		}
+		return false;
+	}
+
+	// method to check if the domain is a gitlab domain
+	private boolean isGitlabDomain(String domain) {
+		if (domain.equals(GITLAB_DOMAIN)) {
+			return true;
+		}
+		return false;
+	}
+
+	// method to check if the domain is a bitbucket domain
+	private boolean isBitbucketDomain(String domain) {
+		if (domain.equals(BIT_BUCKET_DOMAIN)) {
+			return true;
+		}
+		return false;
+	}
+
+	private String getPath(URI repoURI) {
+		String path = repoURI.getPath();
+		if (path.endsWith(".git")) { //$NON-NLS-1$
+			path = path.substring(0, path.length() - 4); // Remove ".git"
+		}
+		return path;
 	}
 
 	private IRepository getRepository() {

--- a/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/repositories/TestsPdeAbapGitRepositoriesUtil.java
+++ b/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/repositories/TestsPdeAbapGitRepositoriesUtil.java
@@ -1,5 +1,7 @@
 package org.abapgit.adt.ui.internal.repositories;
 
+import org.abapgit.adt.backend.model.abapgitrepositories.IRepository;
+import org.abapgit.adt.backend.model.abapgitrepositories.impl.AbapgitrepositoriesFactoryImpl;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRunnable;
@@ -66,6 +68,17 @@ public class TestsPdeAbapGitRepositoriesUtil {
 			}
 		}, new NullProgressMonitor());
 		return projects[0].getProject();
+	}
+	
+	public IRepository createDummyRepository() {
+		IRepository dummy = AbapgitrepositoriesFactoryImpl.eINSTANCE.createRepository();
+		dummy.setUrl("https://github.com/dummy_url");
+		dummy.setPackage("$AP_GITHUB");
+		dummy.setCreatedEmail("dummy_user_one@email.com");
+		dummy.setBranchName("refs/heads/master");
+		dummy.setDeserializedAt("20200322180503");
+		dummy.setStatusText("dummy_status");
+		return dummy;
 	}
 
 	protected void waitInUI(long timeout){

--- a/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/repositories/actions/TestUnitAbapGitRepositoriesOpenAction.java
+++ b/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/repositories/actions/TestUnitAbapGitRepositoriesOpenAction.java
@@ -1,0 +1,50 @@
+package org.abapgit.adt.ui.internal.repositories.actions;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.Assert;
+
+import java.net.URISyntaxException;
+
+import org.abapgit.adt.backend.model.abapgitrepositories.IRepository;
+import org.abapgit.adt.backend.model.abapgitrepositories.impl.AbapgitrepositoriesFactoryImpl;
+import org.abapgit.adt.ui.internal.repositories.AbapGitView;
+import org.abapgit.adt.ui.internal.repositories.TestsPdeAbapGitRepositoriesUtil;
+import org.eclipse.core.runtime.CoreException;
+
+public class TestUnitAbapGitRepositoriesOpenAction {
+
+	private static OpenRepositoryAction openAction;
+	private static AbapGitView view;
+	private static IRepository dummyGitSelection;
+	private static IRepository dummyBitSelection;
+	private static TestsPdeAbapGitRepositoriesUtil utils;
+
+	@BeforeClass
+	public static void setup() throws CoreException {
+		utils = new TestsPdeAbapGitRepositoriesUtil();
+		view = utils.initializeView();
+		// git based host
+		dummyGitSelection = utils.createDummyRepository();
+		// bitbucket host
+		dummyBitSelection = AbapgitrepositoriesFactoryImpl.eINSTANCE.createRepository();
+		dummyBitSelection.setUrl("https://user1234@bitbucket.org/user1234/dummy.git");
+		dummyBitSelection.setPackage("$AP_GITHUB");
+		dummyBitSelection.setCreatedEmail("dummy_user_one@email.com");
+		dummyBitSelection.setBranchName("refs/heads/master");
+		dummyBitSelection.setDeserializedAt("20200322180503");
+		dummyBitSelection.setStatusText("dummy_status");
+		openAction = new OpenRepositoryAction(view);
+	}
+
+	@Test
+	public void testOpenRepositoryInBrowserAction() throws URISyntaxException {
+		String actualGitLink = openAction.getLink(dummyGitSelection);
+		String expectedGitLink = "https://github.com/dummy_url/tree/master";
+		Assert.assertEquals(actualGitLink, expectedGitLink);
+
+		String actualBitLink = openAction.getLink(dummyBitSelection);
+		String expectedBitLink = "https://bitbucket.org/user1234/dummy/src/master";
+		Assert.assertEquals(actualBitLink, expectedBitLink);
+	}
+}


### PR DESCRIPTION
# Workflow update:

## Earlier:
- On invoking **openRepositoryAction** the repository link is opened in default external browser

## Now
- On invoking **openRepositoryAction** link to open in browser link is generated using combination of branch linked to package and repoLink.
- Removed deprecated URL generation 

**Unit test included**