### PR TITLE
Lazy loading of checkbox treeviewer in ModifiedObjectSelection page of PullWizard

### DIFF
--- a/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/wizards/TestPdeAbapGitObjectSelectionPage.java
+++ b/test/org.abapgit.adt.ui.test/src/org/abapgit/adt/ui/internal/wizards/TestPdeAbapGitObjectSelectionPage.java
@@ -52,9 +52,9 @@ public class TestPdeAbapGitObjectSelectionPage {
         wizardPage.selectAllObjectsForRepo(mockRepo, repoUrl);
         // getSelectedObjects should now return all children
         Set<IRepositoryModifiedObjects> selected = wizardPage.getSelectedObjects();
-        assertEquals(1, selected.size());
+        assertEquals(1, selected.size()); 
         IRepositoryModifiedObjects repo = selected.iterator().next();
-        assertEquals(repoUrl, repo.getRepositoryURL());
+        assertEquals(repoUrl, repo.getRepositoryURL()); 
         assertEquals(150, repo.getModifiedObjects().size());
     }
 
@@ -86,6 +86,28 @@ public class TestPdeAbapGitObjectSelectionPage {
             event.type = org.eclipse.swt.SWT.MouseWheel;
             event.widget = tree;
             tree.notifyListeners(org.eclipse.swt.SWT.MouseWheel, event);
+        }
+        // After lazy load, verify that all objects are loaded
+        Object[] children = ((AbapGitWizardPageObjectsSelectionForPull.ModifiedObjectTreeContentProvider)
+            wizardPage.modifiedObjTreeViewer.getContentProvider()).getChildren(mockRepo);
+        assertEquals(150, children.length);
+    }
+
+    @Test
+    public void testLazyLoadViaScrollBarSelectionListener() {
+        // Expand the parent node so the tree is ready for scrolling
+        wizardPage.modifiedObjTreeViewer.expandToLevel(mockRepo, 1);
+        // Get the tree and its vertical scrollbar
+        org.eclipse.swt.widgets.Tree tree = wizardPage.modifiedObjTreeViewer.getTree();
+        org.eclipse.swt.widgets.ScrollBar verticalScrollBar = tree.getVerticalBar();
+        // Simulate pulling the scroll bar to the bottom
+        if (verticalScrollBar != null) {
+            verticalScrollBar.setSelection(verticalScrollBar.getMaximum());
+            // Fire a selection event to trigger the selection listener
+            org.eclipse.swt.widgets.Event event = new org.eclipse.swt.widgets.Event();
+            event.type = org.eclipse.swt.SWT.Selection;
+            event.widget = verticalScrollBar;
+            verticalScrollBar.notifyListeners(org.eclipse.swt.SWT.Selection, event);
         }
         // After lazy load, verify that all objects are loaded
         Object[] children = ((AbapGitWizardPageObjectsSelectionForPull.ModifiedObjectTreeContentProvider)


### PR DESCRIPTION
## **Enhanced Object Selection checkbox tree**

### **Overview**

This update introduces **lazy loading**, **parent–child checkbox synchronization**, and **state persistence** to improve performance and usability when handling large repositories in modifiedObjectSelectionPage in Pull Wizard.

---

### **Key Changes**

* **Lazy Loading on Scroll**

  * Added incremental loading of child objects in batches of 100 per repository.
  * Introduced `repoOffsets`, `tryLazyLoad()`, and `loadNextBatch()` to dynamically load data as the user scrolls.

* **Parent–Child Checkbox Sync**

  * Selecting a parent now selects all children.
  * Unselecting any child automatically unchecks the parent.
  * `"1"` action objects remain permanently checked (cannot be unselected).

* **Checkbox State Persistence**

  * Selections persist correctly even after lazy loading or view refresh.
  * Updated `selectedObjectsForRepository` tracking after every selection change.

* **Logical Selection**

  * Instead of relying on checkstate of object for pulling, current implementation focuses on the logical selection which prevents UI freezes for large repositories when parent is selected.  
