### PR TITLE
Expand nodes by default in object selection page's tree viewer

### DIFF
--- a/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/wizards/AbapGitWizardPageObjectsSelectionForPull.java
+++ b/org.abapgit.adt.ui/src/org/abapgit/adt/ui/internal/wizards/AbapGitWizardPageObjectsSelectionForPull.java
@@ -147,6 +147,10 @@ public class AbapGitWizardPageObjectsSelectionForPull extends WizardPage {
 		if (visible) {
 			this.itemsLoadedPerRepo.clear();
 			this.modifiedObjTreeViewer.refresh();
+			// Expand all root nodes (repositories) to show initially loaded children
+			for (IRepositoryModifiedObjects repository : this.repoToModifiedObjects) {
+				this.modifiedObjTreeViewer.expandToLevel(repository, 1);
+			}
 			if (this.repoToModifiedObjects.isEmpty()) {
 				getContainer().showPage(getNextPage());
 			}


### PR DESCRIPTION
Expand nodes by default in object selection page's tree viewer

- Fixes the issue where nodes in the tree viewer were initially collapsed.
- Sets the initial state of the tree viewer to keep nodes expanded by default.