### PR TITLE
externalrepo EMF model: Reference ADT Core Atom model

### DIFF
--- a/org.abapgit.adt.backend/model/abapgitexternalrepo.ecore
+++ b/org.abapgit.adt.backend/model/abapgitexternalrepo.ecore
@@ -47,7 +47,7 @@
       </eAnnotations>
     </eStructuralFeatures>
     <eStructuralFeatures xsi:type="ecore:EReference" name="links" upperBound="-1"
-        eType="ecore:EClass ../../com.sap.adt.tools.core.base/model/atom.ecore#//AtomLink"
+        eType="ecore:EClass platform:/plugin/com.sap.adt.tools.core.base/model/atom.ecore#//AtomLink"
         containment="true" resolveProxies="false">
       <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
         <details key="kind" value="element"/>

--- a/org.abapgit.adt.backend/model/abapgitexternalrepo.genmodel
+++ b/org.abapgit.adt.backend/model/abapgitexternalrepo.genmodel
@@ -2,7 +2,8 @@
 <genmodel:GenModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
     xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/org.abapgit.adt.backend/src" modelPluginID="org.abapgit.adt.backend"
     modelName="Abapgitexternalrepo" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
-    importerID="org.eclipse.emf.importer.ecore" complianceLevel="8.0" copyrightFields="false"
+    importerID="org.eclipse.emf.importer.ecore" complianceLevel="8.0" copyrightFields="false" usedGenPackages="platform:/plugin/com.sap.adt.tools.core.base/model/atom.genmodel#//atom"
+
     interfaceNamePattern="I{0}" operationReflection="true" importOrganizing="true">
   <foreignModel>abapgitexternalrepo.ecore</foreignModel>
   <genPackages prefix="Abapgitexternalrepo" basePackage="org.abapgit.adt.backend.model"
@@ -37,31 +38,6 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute abapgitexternalrepo.ecore#//ExternalRepositoryInfoRequest/password"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute abapgitexternalrepo.ecore#//ExternalRepositoryInfoRequest/package"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute abapgitexternalrepo.ecore#//ExternalRepositoryInfoRequest/branch"/>
-    </genClasses>
-  </genPackages>
-  <genPackages prefix="Atom" basePackage="com.sap.adt.tools.core.model" resource="XML"
-      disposableProviderFactory="true" ecorePackage="../../com.sap.adt.tools.core.base/model/atom.ecore#/">
-    <genDataTypes ecoreDataType="../../com.sap.adt.tools.core.base/model/atom.ecore#//Uri"/>
-    <genClasses ecoreClass="../../com.sap.adt.tools.core.base/model/atom.ecore#//AtomLink">
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EAttribute ../../com.sap.adt.tools.core.base/model/atom.ecore#//AtomLink/mixed"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute ../../com.sap.adt.tools.core.base/model/atom.ecore#//AtomLink/base"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute ../../com.sap.adt.tools.core.base/model/atom.ecore#//AtomLink/etag"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute ../../com.sap.adt.tools.core.base/model/atom.ecore#//AtomLink/href"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute ../../com.sap.adt.tools.core.base/model/atom.ecore#//AtomLink/hreflang"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute ../../com.sap.adt.tools.core.base/model/atom.ecore#//AtomLink/lang"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute ../../com.sap.adt.tools.core.base/model/atom.ecore#//AtomLink/length"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute ../../com.sap.adt.tools.core.base/model/atom.ecore#//AtomLink/rel"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute ../../com.sap.adt.tools.core.base/model/atom.ecore#//AtomLink/title"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute ../../com.sap.adt.tools.core.base/model/atom.ecore#//AtomLink/type"/>
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EAttribute ../../com.sap.adt.tools.core.base/model/atom.ecore#//AtomLink/anyAttribute"/>
-      <genOperations ecoreOperation="../../com.sap.adt.tools.core.base/model/atom.ecore#//AtomLink/getHrefAsUri"
-          body="return java.util.Optional.ofNullable(getHref()).map(URI::create).orElse(null);"/>
-    </genClasses>
-    <genClasses ecoreClass="../../com.sap.adt.tools.core.base/model/atom.ecore#//DocumentRoot">
-      <genFeatures property="None" notify="false" createChild="false" ecoreFeature="ecore:EAttribute ../../com.sap.adt.tools.core.base/model/atom.ecore#//DocumentRoot/mixed"/>
-      <genFeatures property="None" notify="false" createChild="false" ecoreFeature="ecore:EReference ../../com.sap.adt.tools.core.base/model/atom.ecore#//DocumentRoot/xMLNSPrefixMap"/>
-      <genFeatures property="None" notify="false" createChild="false" ecoreFeature="ecore:EReference ../../com.sap.adt.tools.core.base/model/atom.ecore#//DocumentRoot/xSISchemaLocation"/>
-      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference ../../com.sap.adt.tools.core.base/model/atom.ecore#//DocumentRoot/link"/>
     </genClasses>
   </genPackages>
 </genmodel:GenModel>

--- a/org.abapgit.adt.backend/plugin.xml
+++ b/org.abapgit.adt.backend/plugin.xml
@@ -51,21 +51,6 @@
    </extension>
 
    <extension point="org.eclipse.emf.ecore.generated_package">
-      <!-- @generated abapgitexternalrepo -->
-      <package
-            uri="http://www.w3.org/2005/Atom"
-            class="com.sap.adt.tools.core.model.atom.IAtomPackage"
-            genModel="model/abapgitexternalrepo.genmodel"/>
-   </extension>
-
-   <extension point="org.eclipse.emf.ecore.extension_parser">
-      <!-- @generated abapgitexternalrepo -->
-      <parser
-            type="atom"
-            class="com.sap.adt.tools.core.model.atom.util.AtomResourceFactoryImpl"/>
-   </extension>
-
-   <extension point="org.eclipse.emf.ecore.generated_package">
       <!-- @generated abapgitabapobject -->
       <package
             uri="http://www.sap.com/adt/abapgit/abapObjects"

--- a/org.abapgit.adt.backend/src/org/abapgit/adt/backend/model/abapgitexternalrepo/IBranch.java
+++ b/org.abapgit.adt.backend/src/org/abapgit/adt/backend/model/abapgitexternalrepo/IBranch.java
@@ -2,6 +2,7 @@
  */
 package org.abapgit.adt.backend.model.abapgitexternalrepo;
 
+import com.sap.adt.tools.core.model.atom.IAtomLink;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 
@@ -154,7 +155,7 @@ public interface IBranch extends EObject {
 	 *        extendedMetaData="kind='element' name='link' namespace='http://www.w3.org/2005/Atom'"
 	 * @generated
 	 */
-	EList<com.sap.adt.tools.core.model.atom.IAtomLink> getLinks();
+	EList<IAtomLink> getLinks();
 
 	/**
 	 * Returns the value of the '<em><b>Folder Logic</b></em>' attribute.

--- a/org.abapgit.adt.backend/src/org/abapgit/adt/backend/model/abapgitexternalrepo/impl/AbapgitexternalrepoPackageImpl.java
+++ b/org.abapgit.adt.backend/src/org/abapgit/adt/backend/model/abapgitexternalrepo/impl/AbapgitexternalrepoPackageImpl.java
@@ -2,6 +2,7 @@
  */
 package org.abapgit.adt.backend.model.abapgitexternalrepo.impl;
 
+import com.sap.adt.tools.core.model.atom.IAtomPackage;
 import org.abapgit.adt.backend.model.abapgitexternalrepo.AccessMode;
 import org.abapgit.adt.backend.model.abapgitexternalrepo.IAbapgitexternalrepoFactory;
 import org.abapgit.adt.backend.model.abapgitexternalrepo.IAbapgitexternalrepoPackage;
@@ -110,19 +111,14 @@ public class AbapgitexternalrepoPackageImpl extends EPackageImpl implements IAba
 		isInited = true;
 
 		// Initialize simple dependencies
+		IAtomPackage.eINSTANCE.eClass();
 		XMLTypePackage.eINSTANCE.eClass();
-
-		// Obtain or create and register interdependencies
-		Object registeredPackage = EPackage.Registry.INSTANCE.getEPackage(com.sap.adt.tools.core.model.atom.IAtomPackage.eNS_URI);
-		com.sap.adt.tools.core.model.atom.impl.AtomPackageImpl theAtomPackage = (com.sap.adt.tools.core.model.atom.impl.AtomPackageImpl)(registeredPackage instanceof com.sap.adt.tools.core.model.atom.impl.AtomPackageImpl ? registeredPackage : com.sap.adt.tools.core.model.atom.IAtomPackage.eINSTANCE);
 
 		// Create package meta-data objects
 		theAbapgitexternalrepoPackage.createPackageContents();
-		theAtomPackage.createPackageContents();
 
 		// Initialize created meta-data
 		theAbapgitexternalrepoPackage.initializePackageContents();
-		theAtomPackage.initializePackageContents();
 
 		// Mark meta-data to indicate it can't be changed
 		theAbapgitexternalrepoPackage.freeze();
@@ -457,7 +453,7 @@ public class AbapgitexternalrepoPackageImpl extends EPackageImpl implements IAba
 
 		// Obtain other dependent packages
 		XMLTypePackage theXMLTypePackage = (XMLTypePackage)EPackage.Registry.INSTANCE.getEPackage(XMLTypePackage.eNS_URI);
-		com.sap.adt.tools.core.model.atom.IAtomPackage theAtomPackage = (com.sap.adt.tools.core.model.atom.IAtomPackage)EPackage.Registry.INSTANCE.getEPackage(com.sap.adt.tools.core.model.atom.IAtomPackage.eNS_URI);
+		IAtomPackage theAtomPackage = (IAtomPackage)EPackage.Registry.INSTANCE.getEPackage(IAtomPackage.eNS_URI);
 
 		// Create type parameters
 

--- a/org.abapgit.adt.backend/src/org/abapgit/adt/backend/model/abapgitexternalrepo/impl/BranchImpl.java
+++ b/org.abapgit.adt.backend/src/org/abapgit/adt/backend/model/abapgitexternalrepo/impl/BranchImpl.java
@@ -2,6 +2,7 @@
  */
 package org.abapgit.adt.backend.model.abapgitexternalrepo.impl;
 
+import com.sap.adt.tools.core.model.atom.IAtomLink;
 import java.util.Collection;
 import org.abapgit.adt.backend.model.abapgitexternalrepo.IAbapgitexternalrepoPackage;
 import org.abapgit.adt.backend.model.abapgitexternalrepo.IBranch;
@@ -143,7 +144,7 @@ public class BranchImpl extends MinimalEObjectImpl.Container implements IBranch 
 	 * @generated
 	 * @ordered
 	 */
-	protected EList<com.sap.adt.tools.core.model.atom.IAtomLink> links;
+	protected EList<IAtomLink> links;
 
 	/**
 	 * The default value of the '{@link #getFolderLogic() <em>Folder Logic</em>}' attribute.
@@ -305,9 +306,9 @@ public class BranchImpl extends MinimalEObjectImpl.Container implements IBranch 
 	 * @generated
 	 */
 	@Override
-	public EList<com.sap.adt.tools.core.model.atom.IAtomLink> getLinks() {
+	public EList<IAtomLink> getLinks() {
 		if (links == null) {
-			links = new EObjectContainmentEList<com.sap.adt.tools.core.model.atom.IAtomLink>(com.sap.adt.tools.core.model.atom.IAtomLink.class, this, IAbapgitexternalrepoPackage.BRANCH__LINKS);
+			links = new EObjectContainmentEList<IAtomLink>(IAtomLink.class, this, IAbapgitexternalrepoPackage.BRANCH__LINKS);
 		}
 		return links;
 	}
@@ -401,7 +402,7 @@ public class BranchImpl extends MinimalEObjectImpl.Container implements IBranch 
 				return;
 			case IAbapgitexternalrepoPackage.BRANCH__LINKS:
 				getLinks().clear();
-				getLinks().addAll((Collection<? extends com.sap.adt.tools.core.model.atom.IAtomLink>)newValue);
+				getLinks().addAll((Collection<? extends IAtomLink>)newValue);
 				return;
 			case IAbapgitexternalrepoPackage.BRANCH__FOLDER_LOGIC:
 				setFolderLogic((String)newValue);


### PR DESCRIPTION
Reference the ADT Core Atom EMF model instead of generating it.

Fixes error log entries:
!MESSAGE Both 'com.sap.adt.tools.core.base' and 'org.abapgit.adt.backend' register a package for 'http://www.w3.org/2005/Atom' !MESSAGE Both 'com.sap.adt.tools.core.base' and 'org.abapgit.adt.backend' register an extension parser for 'atom'