### PR TITLE
Build and Release workflow [Github Action]

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,127 @@
+name: Automated Tycho Build and Update Site Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'The tag version to build and release (e.g., v1.6.5)'
+        required: true
+        type: string
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      # Step 1: Extract Version Number from the Manual Input and set it as an OUTPUT
+      - name: Extract version
+        id: get_version
+        run: |
+          INPUT_TAG="${{ github.event.inputs.release_tag }}"
+          VERSION="${INPUT_TAG#v}"
+          # Setting a step output is the supported way to pass data between steps safely
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+
+      # Step 2: Checkout the primary code repository matching your requested tag
+      - name: Checkout Code Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.release_tag }}
+          fetch-depth: 0
+
+      # Step 3: Explicitly set up Java
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      # Step 4: Programmatically update Tycho Versions
+      - name: Update Tycho Project Version
+        run: |
+          mvn tycho-versions:set-version -DnewVersion=${{ steps.get_version.outputs.VERSION }}
+
+      # Step 5: Commit and push the updated pom.xml / MANIFEST.MF files
+      - name: Commit and Push Updated Tycho Versions
+        run: |
+          # Set up git bot signature
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+          # Check if tycho-versions actually modified files
+          if [ -n "$(git status --porcelain)" ]; then
+            git add .
+            git commit -m "Bump Tycho project version to ${{ steps.get_version.outputs.VERSION }}"
+            
+            # Extract the raw input branch/tag name (e.g., v1.7.13 or release-1.7)
+            TARGET_REF="${{ github.event.inputs.release_tag }}"
+            
+            echo "Pushing updated version files back to origin tracking reference: ${TARGET_REF}"
+            
+            # Push HEAD directly to the matching branch name on origin
+            git push origin HEAD:${TARGET_REF}
+          else
+            echo "No version changes detected."
+          fi
+
+      # Step 6: Clean verify the artifacts
+      - name: Run Maven Build with UI config
+        run: |
+          xvfb-run --auto-servernum -s "-screen 0 1024x768x24" mvn clean verify
+
+      # Step 7: Package target repository into an archive
+      - name: Zip P2 Update Site Repository
+        run: |
+          cd org.abapgit.adt.updatesite/target/repository
+          zip -r ../../../abapGit_ADT_${{ steps.get_version.outputs.VERSION }}.zip .
+          cd ../../..
+
+      # Step 8: Draft and publish GitHub Release in ADT_Frontend Code repository
+      - name: Create GitHub Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.get_version.outputs.VERSION }}
+          name: v${{ steps.get_version.outputs.VERSION }}
+          draft: false
+          prerelease: false
+          files: abapGit_ADT_${{ steps.get_version.outputs.VERSION }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Step 9: Deploy directly to the secondary Update Site Repository
+      - name: Checkout Update Site Repo
+        uses: actions/checkout@v4
+        with:
+          repository: 'aarnapant-sap/eclipse.abapgit.org'
+          ssh-key: ${{ secrets.SSH_DEPLOY_KEY }}
+          path: 'update-site-repo'
+
+      # Step 10: Sync new release binaries into the update site
+      - name: Copy Files & Push to Update Site
+        run: |
+          # Define absolute paths using the step output reference
+          SRC_ZIP_DIR="$GITHUB_WORKSPACE/org.abapgit.adt.updatesite/target/repository"
+          DEST_DIR="$GITHUB_WORKSPACE/update-site-repo/updatesite"
+          VERSION_NUM="${{ steps.get_version.outputs.VERSION }}"
+          
+          # Force clean copy of build artifacts
+          mkdir -p $DEST_DIR
+          cp -r $SRC_ZIP_DIR/* $DEST_DIR/
+          
+          # Change tracking directory to update site repo context
+          cd $GITHUB_WORKSPACE/update-site-repo
+          
+          # Setup Git signature context for automation tracking
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+          # Check for structural updates, create branch, and push changes
+          if [ -n "$(git status --porcelain)" ]; then
+            git checkout -b "new-release-v${VERSION_NUM}"
+            git add .
+            git commit -m "Update site binaries for release v${VERSION_NUM}"
+            git push origin "new-release-v${VERSION_NUM}"
+          else
+            echo "No changes found in the generated build output update site."
+          fi


### PR DESCRIPTION
This PR introduces a fully automated GitHub Actions workflow **`(workflow_dispatch)`** that orchestrates the compilation, version bumping, and multi-repo deployment pipeline for AbapGit Frontend component.

## Configuration prerequisite
### For generating and configuring `SSH_DEPLOY_KEY` for the update_site rep follow these steps:
run following command to generate public/private key pair for deploy key setup
```bash
ssh-keygen -t ed25519 -C "actions-deploy-key" -f id_updatesite -N ""
```
- This creates two files: id_updatesite (Private Key) and id_updatesite.pub (Public Key).
- In the **`update-site`** repo navigate to `settings` > `deploy keys`.
- Add the generated public key `id_updatesite.pub` as a deploy key.
- Now, in the ADT_Frontend repo navigate to `settings` > `secrets and variables` > `action`.
- Add the private key as a repository secret.

## Steps to create a new release:
 - Once your changes are merged in master checkout to a new version branch e.g. `v1.8.1`.
 - Trigger the manual workflow `Automated Tycho Build and Update Site Release`.
 - Post triggering the workflow user will be prompted for the intended version like so `v1.8.1`.
 - Click `start workflow`.
 - Once the workflow completes merge both version branches `v1.8.1` to their respective main in `ADT_Frontend` and in `update-site` repo.
 
 ## Architectural flow
 ```mermaid
graph TD
    %% Define Styles
    classDef primary fill:#e1f5fe,stroke:#0288d1,stroke-width:2px,color:#000;
    classDef secondary fill:#efebe9,stroke:#5d4037,stroke-width:2px,color:#000;
    classDef trigger fill:#fff3e0,stroke:#f57c00,stroke-width:2px,color:#000;

    %% Nodes
    Start([Manual Trigger: Input Tag]) ---> Repo1

    subgraph Repo1 [PRIMARY REPOSITORY: Code & Release]
        direction TB
        A[1. Extract Version] --> B[2. Checkout Code]
        B --> C[3. Tycho Version Bump]
        C --> D[4. Commit & Push to Branch]
        D --> E[5. Headless Maven Build]
        E --> F[6. Create GitHub Release & Zip]
    end

    F ====>|Auth: SSH Deploy Key| Repo2

    subgraph Repo2 [SECONDARY REPOSITORY: eclipse.abapgit.org]
        direction TB
        G[7. Checkout Site Repo] --> H[8. Sync Built Binaries]
        H --> I[9. Push to Release Branch]
    end

    %% Apply Styles
    class Start trigger;
    class A,B,C,D,E,F primary;
    class G,H,I secondary;
```
 